### PR TITLE
Time functions in gettime.cc, added support for OS X

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 annabellincludedir = ${includedir}/annabell
-annabellinclude_HEADERS = display.h  enum_ssm.h  fssm.h  interface.h  monitor.h  rnd.h  sizes.h  sllm.h  ssm.h
+annabellinclude_HEADERS = display.h  enum_ssm.h  fssm.h  interface.h  monitor.h  rnd.h  sizes.h  sllm.h  ssm.h  gettime.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = annabell_main.cc sllm.cc ssm.cc interface.cc monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc
+annabell_SOURCES = annabell_main.cc sllm.cc ssm.cc interface.cc monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.c
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ annabellinclude_HEADERS = display.h  enum_ssm.h  fssm.h  interface.h  monitor.h 
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = annabell_main.cc sllm.cc ssm.cc interface.cc monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.c
+annabell_SOURCES = annabell_main.cc sllm.cc ssm.cc interface.cc monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc 
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "rnd.h"
 #include "display.h" 
 #include <sys/time.h>
+#include "gettime.h" 
 
 using namespace std;
 using namespace sizes;
@@ -156,7 +157,7 @@ int main()
 int Interface(sllm *SLLM, monitor *Mon)
 {
   std::string input_line;
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
 
   for(;;) {
     std::cout << "Enter command: ";
@@ -211,14 +212,14 @@ int ParseCommand(sllm *SLLM, monitor *Mon, std::string input_line)
     // answer time
     if (AnswerTimeFlag && AnswerTimeUpdate && AnswerTimePhrase!="") {
       struct timespec clk0, clk1;
-      clock_gettime( CLOCK_REALTIME, &clk0);
+      GetRealTime(&clk0);
 
       AnswerTimeUpdate=false;
       ExecuteAct(SLLM, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
       GetInputPhrase(SLLM, Mon, AnswerTimePhrase);
       Exploitation(SLLM, Mon, 1);
 
-      clock_gettime( CLOCK_REALTIME, &clk1);
+      GetRealTime(&clk1);
       double answ_time = clk1.tv_sec - clk0.tv_sec
 	+ (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
       double link_num = (double)SLLM->ElActfSt->CountSparseInputLinks();
@@ -830,7 +831,7 @@ int ParseCommand(sllm *SLLM, monitor *Mon, std::string input_line)
       return 1;
     }
 
-    clock_gettime( CLOCK_REALTIME, &clk1);
+    GetRealTime(&clk1);
 
     Display.Print("Elapsed time: " + to_string
 		  ((double)(clk1.tv_sec - clk0.tv_sec)
@@ -1092,13 +1093,13 @@ int ParseCommand(sllm *SLLM, monitor *Mon, std::string input_line)
     }
 
     struct timespec clk0, clk1;
-    clock_gettime( CLOCK_REALTIME, &clk0);
+    GetRealTime(&clk0);
     
     ExecuteAct(SLLM, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
     GetInputPhrase(SLLM, Mon, AnswerTimePhrase);
     Exploitation(SLLM, Mon, 1);
 
-    clock_gettime( CLOCK_REALTIME, &clk1);
+    GetRealTime(&clk1);
     double answ_time = clk1.tv_sec - clk0.tv_sec
       + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
     double link_num = (double)SLLM->ElActfSt->CountSparseInputLinks();

--- a/src/fssm.cc
+++ b/src/fssm.cc
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 #include "fssm.h"
 #include "rnd.h"
+#include "gettime.h"
 
 using namespace std;
 
@@ -36,7 +37,7 @@ int fssm::Activ()
   struct timespec clk0, clk1;
 
   if (SparseLkFlag) return SparseActiv();
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
   Forced=false;
   ActivVect.clear();
   for (unsigned int iv=0; iv<SparseRef.size(); iv++) {
@@ -53,7 +54,7 @@ int fssm::Activ()
     }
   }
 
-  clock_gettime( CLOCK_REALTIME, &clk1);
+  GetRealTime(&clk1);
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -64,7 +65,7 @@ int fssm::Out()
 {
   struct timespec clk0, clk1;
 
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
   Clear();
 
   for(unsigned int i=0; i<ActivVect.size(); i++) {
@@ -77,7 +78,7 @@ int fssm::Out()
   }
   SetDefault();
 
-  clock_gettime( CLOCK_REALTIME, &clk1);
+  GetRealTime(&clk1);
   out_time = out_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -436,7 +437,7 @@ int fssm2d::Activ()
   fssm::Activ();
   struct timespec clk0, clk1;
 
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
   for (unsigned int iv=0; iv<SparseRefRow.size(); iv++) {
     for (unsigned int i=0; i<SparseRefRow[iv]->size(); i++) {
       int ix = SparseRefRow[iv]->at(i);
@@ -470,7 +471,7 @@ int fssm2d::Activ()
     }
   }
 
-  clock_gettime( CLOCK_REALTIME, &clk1);
+  GetRealTime(&clk1);
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -481,7 +482,7 @@ int fssm2d::Out()
 {
   struct timespec clk0, clk1;
 
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
   NHigh = 0;
   for(unsigned int i=0; i<HighVect.size(); i++) {
     int inr = HighVect[i];
@@ -511,7 +512,7 @@ int fssm2d::Out()
   }
   SetDefault();
   
-  clock_gettime( CLOCK_REALTIME, &clk1);
+  GetRealTime(&clk1);
   out_time = out_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 

--- a/src/gettime.cc
+++ b/src/gettime.cc
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2015 Bruno Golosio
+Copyright (C) 2015 Alfio E. Fresta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/time.h>
+#include "gettime.h"
+
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+void GetRealTime(struct timespec* clk)
+{
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+  // src. http://stackoverflow.com/a/6725161 
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  clk->tv_sec = mts.tv_sec;
+  clk->tv_nsec = mts.tv_nsec;
+#else
+  clock_gettime(CLOCK_REALTIME, &clk);
+#endif
+}
+
+void GetMonotonicTime(struct timespec* clk)
+{
+#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+  // src. http://stackoverflow.com/a/6725161 
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  clk->tv_sec = mts.tv_sec;
+  clk->tv_nsec = mts.tv_nsec;
+#else
+  clock_gettime(CLOCK_MONOTONIC, &clk);
+#endif
+}

--- a/src/gettime.h
+++ b/src/gettime.h
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2015 Bruno Golosio
+Copyright (C) 2015 Alfio E. Fresta
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GETTIMEH
+#define GETTIMEH
+
+#include <sys/time.h>
+#include "gettime.h"
+
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#endif
+
+void GetRealTime(struct timespec* clk);
+void GetMonotonicTime(struct timespec* clk);
+
+#endif

--- a/src/ssm.cc
+++ b/src/ssm.cc
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 #include "ssm.h"
 #include "rnd.h"
+#include "gettime.h"
 
 using namespace std;
 
@@ -500,7 +501,7 @@ int ssm::SparseActiv()
   //float DefaultMinWg = -1; // put in header
   struct timespec clk0, clk1;
 
-  //clock_gettime( CLOCK_MONOTONIC, &clk0);
+  //GetMonotonicTime(&clk0);
 
   //int n_high=SparseNHighIn();
   float min_in_sign = SparseMinInSign();
@@ -511,7 +512,7 @@ int ssm::SparseActiv()
   }
 
   Forced=false;
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   for (unsigned int issm=0; issm<SparseInSSM.size(); issm++) {
     float wgmin = SparseInMinWeight[issm];
     vssm *ssm1=SparseInSSM[issm];
@@ -532,7 +533,7 @@ int ssm::SparseActiv()
       }
     }
   }
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
+  GetMonotonicTime(&clk1);
 
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
@@ -548,14 +549,14 @@ int ssm::Activ()
   }
 
   struct timespec clk0, clk1;
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   Forced=false;
   for(int i=0; i<NN(); i++) {
     Nr[i]->Activ();
     Nr[i]->A += GB;
   }
 
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
+  GetMonotonicTime(&clk1);
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -567,7 +568,7 @@ int ssm::Out()
   struct timespec clk0, clk1;
   int N;
   
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   NHigh = 0;
   if (FillHighVect) HighVect.clear();
 
@@ -582,7 +583,7 @@ int ssm::Out()
   }
   SetDefault();
 
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   out_time = out_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
   return 0;
@@ -1038,7 +1039,7 @@ int ssm2d::Out()
 {
   struct timespec clk0, clk1;
 
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   NHigh = 0;
   if (FillHighVect) HighVect.clear();
   if (FillHighVectRow) HighVectRow.clear();
@@ -1069,7 +1070,7 @@ int ssm2d::Out()
   }
   SetDefault();
 
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
+  GetMonotonicTime(&clk1);
   out_time = out_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -1384,7 +1385,7 @@ int ssm_as::AsOut()
   if (WTA_FLAG==T_NEW_WTA || WTA_FLAG==T_NEW_KWTA) N = NewWnnNum;
   else N = NN();
 
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   bool null_in=NullIn();
   if (null_in && Forced==false) {
     //cout << "null in\n";
@@ -1464,7 +1465,7 @@ int ssm_as::AsOut()
   }
   */
 
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
+  GetMonotonicTime(&clk1);
   as_time = as_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 

--- a/src/ssm_cuda.cc
+++ b/src/ssm_cuda.cc
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <stdlib.h>
 #include "ssm.h"
+#include "gettime.h"
 
 using namespace std;
 
@@ -103,7 +104,7 @@ int ssm_as::cuda_SparseActiv()
   struct timespec clk0, clk1;
   struct timespec clkh0, clkh1;
 
-  clock_gettime( CLOCK_MONOTONIC, &clkh0);
+  GetMonotonicTime(&clkh0);
 
   //int n_high=SparseNHighIn();
   float min_in_sign = SparseMinInSign();
@@ -119,7 +120,7 @@ int ssm_as::cuda_SparseActiv()
   //cout << NN() << endl;
 
   Forced=false;
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
   NRows = 0;
   for (unsigned int issm=0; issm<SparseInSSM.size(); issm++) {
     vssm *ssm1=SparseInSSM[issm];
@@ -173,8 +174,8 @@ int ssm_as::cuda_SparseActiv()
   delete[] Nlk;
   delete[] in_sign_arr;
 
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
-  clock_gettime( CLOCK_MONOTONIC, &clkh1);
+  GetMonotonicTime(&clk1);
+  GetMonotonicTime(&clkh1);
 
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;

--- a/src/ssm_cuda.cu
+++ b/src/ssm_cuda.cu
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include "sizes.h"
 #include "cuPrintf.cu"
+#include "gettime.h"
 
 using namespace std;
 using namespace sizes;
@@ -135,7 +136,7 @@ int cuda_SparseActiv_fn(int NRows, int **LkPt, int *Nlk,
   float *dev_in_sign;
   struct timespec clk0, clk1;
 
-  //gpuErrchk( cudaDeviceSynchronize() ); clock_gettime( CLOCK_MONOTONIC, &clk0);
+  //gpuErrchk( cudaDeviceSynchronize() ); GetMonotonicTime(&clk0);
   gpuErrchk(cudaMalloc((void**)&dev_LkPt, NRows*sizeof(int*)));
   gpuErrchk(cudaMalloc((void**)&dev_Nlk, NRows*sizeof(int)));
   gpuErrchk(cudaMalloc( (void**)&dev_in_sign, NRows*sizeof(float)));
@@ -150,7 +151,7 @@ int cuda_SparseActiv_fn(int NRows, int **LkPt, int *Nlk,
   gpuErrchk(cudaMemcpy(dev_activ_arr, activ_arr, NN*sizeof(float),
     cudaMemcpyHostToDevice));
 
-  gpuErrchk( cudaDeviceSynchronize() ); clock_gettime( CLOCK_MONOTONIC, &clk0);
+  gpuErrchk( cudaDeviceSynchronize() ); GetMonotonicTime(&clk0);
   kernel_SparseActiv_blk1<<< 65535, 512 >>>(NRows, dev_LkPt, dev_Nlk,
     dev_in_sign, dev_activ_arr);
   gpuErrchk( cudaPeekAtLastError() );
@@ -159,7 +160,7 @@ int cuda_SparseActiv_fn(int NRows, int **LkPt, int *Nlk,
     dev_in_sign, dev_activ_arr);
   gpuErrchk( cudaPeekAtLastError() );
   gpuErrchk( cudaDeviceSynchronize() );
-  gpuErrchk( cudaDeviceSynchronize() ); clock_gettime( CLOCK_MONOTONIC, &clk1);
+  gpuErrchk( cudaDeviceSynchronize() ); GetMonotonicTime(&clk1);
 
   gpuErrchk(cudaMemcpy(activ_arr, dev_activ_arr, NN*sizeof(float),
              cudaMemcpyDeviceToHost));
@@ -168,7 +169,7 @@ int cuda_SparseActiv_fn(int NRows, int **LkPt, int *Nlk,
   gpuErrchk(cudaFree(dev_Nlk));
   gpuErrchk(cudaFree(dev_in_sign));
 
-  //gpuErrchk(cudaDeviceSynchronize()); clock_gettime( CLOCK_MONOTONIC, &clk1);
+  //gpuErrchk(cudaDeviceSynchronize()); GetMonotonicTime(&clk1);
 
   cuda_time = cuda_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;

--- a/src/ssm_omp.cc
+++ b/src/ssm_omp.cc
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include "ssm.h"
 #include <omp.h>
+#include "gettime.h"
 using namespace std;
 
 #define THREAD_MAXNUM omp_get_max_threads()
@@ -30,7 +31,7 @@ int ssm_as::OMPActiv()
   if (WTA_FLAG==T_NEW_WTA || WTA_FLAG==T_NEW_KWTA) N = NewWnnNum;
   else N = NN();
 
-  clock_gettime( CLOCK_REALTIME, &clk0);
+  GetRealTime(&clk0);
 
   Forced=false;
   int i;
@@ -48,7 +49,7 @@ int ssm_as::OMPActiv()
     }
   }
 
-  clock_gettime( CLOCK_REALTIME, &clk1);
+  GetRealTime(&clk1);
   act_time = act_time
     + clk1.tv_sec - clk0.tv_sec + (double)(clk1.tv_nsec - clk0.tv_nsec)*1e-9;
 
@@ -90,7 +91,7 @@ int ssm_as::OMPSparseActiv()
   //  Nr[i]->A = Nr[i]->B + GB - n_high;
   //}
   Forced=false;
-  clock_gettime( CLOCK_MONOTONIC, &clk0);
+  GetMonotonicTime(&clk0);
 #pragma omp parallel for default(shared) collapse(1)
   for (unsigned int issm=0; issm<SparseInSSM.size(); issm++) {
     float wgmin = SparseInMinWeight[issm];
@@ -120,7 +121,7 @@ int ssm_as::OMPSparseActiv()
       //}
     }
   }
-  clock_gettime( CLOCK_MONOTONIC, &clk1);
+  GetMonotonicTime(&clk1);
 
 #pragma omp parallel for default(shared) collapse(1)
   for(int i=0; i<N; i++) {


### PR DESCRIPTION
Today I tried to build the project on my OS X laptop and it failed due to the lack of the `clock_gettime` fuction, which is Linux-specific. As it is pretty odd for a Linux application not to be portable to other *NIX platforms, and as the rest of the code seemed to be otherwise portable to Mac, I decided to try and add support for OS X.

This pull request:

- Introduces `gettime.cc`, which includes two utility functions:
  
  ```c++
  void GetRealTime(struct timespec* clk);
  void GetMonotonicTime(struct timespec* clk);
  ``` 
  These are equivalent to calling respectively, on Linux/BSD,
  ```c++
  void clock_gettime(CLOCK_REALTIME, struct timespec* clk);
  void clock_gettime(CLOCK_MONOTONIC, struct timespec* clk);
  ``` 

- On Linux and BSD, `clock_gettime` is used internally,
- On Mach (OS X), where `clock_gettime` is not available, functionally equivalent methods are internally used to retrieve the time in a compatible format. As `gcc` and all the other libraries are available, this effectively adds support for Mac OS X (tested on OS X El Capitan).
- I replaced all of the occurrences of `clock_gettime` with the respective utility functions provided in `gettime.c`.
- Given some portability of the other libraries, the separation of the time functions can be useful as a starting point to add support for more platforms not using `clock_gettime`, e.g. Windows.

Note: The monotonic time function on OS X is implemented using "SYSTEM_TIME", which is the number of seconds passed since the system was booted. As this is not affected by clock adjustments from the user, this should be equivalent to the monotonic time, as described by the Linux manual.

I hope this will be of some help.