### PR TITLE
Added Eclipse IDE files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ libtool
 .deps
 *.gz
 *.tgz
+/.autotools
+/.cproject
+/.project
+/m4/
+/.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ libtool
 /.autotools
 /.cproject
 /.project
-/m4/
 /.settings/


### PR DESCRIPTION
I'm using Eclipse IDE so I've added Eclipse metadata files to .gitignore. 
I think it is useful to keep them ignored in the base repo so people that may fork it and use Eclipse do not add these files to any commit by mistake.