### PR TITLE
Extracted plural processing to new class CommandUtils

### DIFF
--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -1,0 +1,25 @@
+#ifndef SRC_COMMANDUTILS_H_
+#define SRC_COMMANDUTILS_H_
+
+#include <string>
+
+using namespace std;
+
+class CommandUtils {
+public:
+	/**
+	 * This function takes care of plural suffix.
+	 * ie. replaces plural occurences with "-s"
+	 * @param input a string
+	 * @return "-s" if the input represents a plural, and the unchanged input otherwise.
+	 */
+	static string processPlural(string input) {
+		if (input == "-es") {
+			return "-s";
+		} else {
+			return input;
+		}
+	}
+};
+
+#endif /* SRC_COMMANDUTILS_H_ */

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ann_exception.h"
 #include <sys/time.h>
 #include "gettime.h" 
+#include "CommandUtils.h"
 
 using namespace std;
 using namespace sizes;
@@ -193,9 +194,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
 			buf1 = "a"; // take care of article
 		}
 
-		if (buf1 == "-es") {
-			buf1 = "-s"; // take care of plural suffix
-		}
+		buf1 = CommandUtils::processPlural(buf1);
 
 		buf = buf + buf1;
 		if (buf[0] == '/' || buf[0] == '<') {


### PR DESCRIPTION
Hi Bruno,
I've created a new class [CommandUtils](https://github.com/jotadepicas/annabell/blob/master/src/CommandUtils.h) to begin extracting string processing outside annabell_main. 
As a first step and example, I've extracted just the plural suffix processing.

One comment: I haven't updated src/Makefile.am to add CommandUtils.h because everything seems to be compiling without doing so, let me know if you get any compile errors (and sorry in advance if you do :/)

Also, I've started a repo for creating Unit Tests, to ensure everything keeps working as expected. Have a look at [annabell-tests](https://github.com/jotadepicas/annabell-tests).

I think this tests should be a part of your main repo, because otherwise they will be inevitably outdated if someone changes the code without updating the tests. Moreover, running tests could be enforced in the make of the project. But for this, I think the main repo structure should be changed, so the root directory contains both projects (annabell and annabell-tests).

Let me know what you think, or if you have any trouble running the tests.

best,
-Juan