### PR TITLE
Object-oriented refactors

### DIFF
--- a/src/Annabell.cc
+++ b/src/Annabell.cc
@@ -1641,3 +1641,19 @@ int Annabell::StActRwdUpdate()
   return 0;
 }
 
+int Annabell::SetAct(int acq_act, int el_act) {
+	this->AcqAct->Fill((int*) v_acq_act[acq_act]);
+	this->ElActFL->Fill((int*) v_el_act[el_act]);
+	this->ElAct->Fill((int*) v_el_act[el_act]);
+
+	return 0;
+}
+
+int Annabell::SetAct(int rwd_act, int acq_act, int el_act) {
+	this->RwdAct->Fill((int*) v_rwd_act[rwd_act]);
+	this->AcqAct->Fill((int*) v_acq_act[acq_act]);
+	this->ElActFL->Fill((int*) v_el_act[el_act]);
+	this->ElAct->Fill((int*) v_el_act[el_act]);
+
+	return 0;
+}

--- a/src/Annabell.cc
+++ b/src/Annabell.cc
@@ -25,8 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 using namespace std;
 using namespace sizes;
 
-Annabell::Annabell()
-{
+Annabell::Annabell() {
+  flags = new AnnabellFlags();
   CudaFlag = false;
   W = new ssm(WSize);
   IW = new ssm(WMSize);

--- a/src/Annabell.h
+++ b/src/Annabell.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef SLLMH
 #define SLLMH
+#include "AnnabellFlags.h"
 #include "fssm.h"
 #define FAST_SSM       // Comment to use slow version.
 //#define FAST_SSM_AS    // Comment to use slow version.
@@ -120,9 +121,11 @@ const int v_rwd_act[RwdActSize+1][RwdActSize] = {
   {0,0,0,0,0,0,0,0,0,0,0,0,0,0,1}, // RWD_ACT_14
 };
 
-class Annabell
-{
- public:
+class Annabell {
+public:
+	/** general behaviour and configuration flags */
+	AnnabellFlags* flags;
+
   bool CudaFlag;
   static const float BIGWG=1e20;
   ssm *W;

--- a/src/Annabell.h
+++ b/src/Annabell.h
@@ -664,6 +664,8 @@ public:
   int GoalArch();
   int AddGoalRef();
   int GoalUpdate();
+  int SetAct(int acq_act, int el_act);
+  int SetAct(int rwd_act, int acq_act, int el_act);
 
 };
 

--- a/src/AnnabellFlags.cc
+++ b/src/AnnabellFlags.cc
@@ -1,0 +1,22 @@
+#include "AnnabellFlags.h"
+
+AnnabellFlags::AnnabellFlags() {
+	VerboseFlag = false;
+	StartContextFlag = true;
+	PeriodFlag = false;
+	SpeakerFlag = false;
+	AnswerTimeFlag = false;
+	AnswerTimeUpdate = false;
+	AutoSaveLinkFlag = false;
+
+	AutoSaveLinkIndex = 0;
+	AutoSaveLinkStep = 2000000;
+
+	AnswerTimePhrase = "? do you have any friend -s";
+	SpeakerName = "HUM";
+}
+
+AnnabellFlags::~AnnabellFlags() {
+	// TODO Auto-generated destructor stub
+}
+

--- a/src/AnnabellFlags.h
+++ b/src/AnnabellFlags.h
@@ -1,0 +1,32 @@
+#ifndef SRC_ANNABELLFLAGS_H_
+#define SRC_ANNABELLFLAGS_H_
+
+#include <string>
+
+using namespace std;
+
+/**
+ * Utilitary class for grouping all flags and global configurations.
+ * This will be likely replaced in the future, but as the refactor is ongoing,
+ * it is better to group them here than having them in the global namespace.
+ */
+class AnnabellFlags {
+public:
+	AnnabellFlags();
+	virtual ~AnnabellFlags();
+	bool VerboseFlag;
+	bool StartContextFlag;
+	bool PeriodFlag;
+	bool SpeakerFlag;
+	bool AnswerTimeFlag;
+	bool AnswerTimeUpdate;
+	bool AutoSaveLinkFlag;
+
+	int AutoSaveLinkIndex;
+	long AutoSaveLinkStep;
+
+	string AnswerTimePhrase;
+	string SpeakerName;
+};
+
+#endif /* SRC_ANNABELLFLAGS_H_ */

--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -33,6 +33,21 @@ public:
 			return input;
 		}
 	}
+
+	/**
+	 * @returns true if input string starts with provided character, false otherwise.
+	 */
+	static bool startsWith(string input, char character) {
+		return input[0] == character;
+	}
+
+	/**
+	 * @returns true if input string ends with provided character, false otherwise.
+	 */
+	static bool endsWith(string input, char character) {
+		int lastIndex = input.size() - 1;
+		return input[lastIndex] == character;
+	}
 };
 
 #endif /* SRC_COMMANDUTILS_H_ */

--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -20,6 +20,19 @@ public:
 			return input;
 		}
 	}
+
+	/**
+	 * This function takes care of the articles, simplifying "an" occurrences to "a".
+	 * @param input a string
+	 * @return "a" if the input is "an", and the unchanged input otherwise.
+	 */
+	static string processArticle(string input) {
+		if (input == "an") {
+			return "a";
+		} else {
+			return input;
+		}
+	}
 };
 
 #endif /* SRC_COMMANDUTILS_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h
+annabellinclude_HEADERS = AnnabellFlags.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc 
+annabell_SOURCES = AnnabellFlags.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc 
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -195,9 +195,9 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
 		buf1 = CommandUtils::processPlural(buf1);
 
 		buf = buf + buf1;
-		if (buf[0] == '/' || buf[0] == '<') {
+		if (buf[0] == '/') {
 			int l = buf.size() - 1;
-			if ((buf[0] == '/' && buf[l] != '/') || (buf[0] == '<' && buf[l] != '>')) {
+			if (buf[0] == '/' && buf[l] != '/') {
 				buf = buf + " ";
 				continue;
 			}

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -195,12 +195,10 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
 		buf1 = CommandUtils::processPlural(buf1);
 
 		buf = buf + buf1;
-		if (buf[0] == '/') {
-			int l = buf.size() - 1;
-			if (buf[0] == '/' && buf[l] != '/') {
-				buf = buf + " ";
-				continue;
-			}
+
+		if (CommandUtils::startsWith(buf, '/') && !CommandUtils::endsWith(buf, '/')) {
+			buf = buf + " ";
+			continue;
 		}
 
 		input_token.push_back(buf);

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -44,8 +44,6 @@ int ExplorationPhaseIdx;
 int StoredStActI;
 display Display;
 
-AnnabellFlags* flags;
-
 struct timespec clk0, clk1;
 
 int GetInputPhrase(Annabell *annabell, Monitor *Mon, string input_phrase);
@@ -79,7 +77,6 @@ string to_string(T const& value) {
 }
 
 int main() {
-	flags = new AnnabellFlags();
 	Display.LogFileFlag = false;
 	Display.ConsoleFlag = true;
 
@@ -134,9 +131,9 @@ int SetAct(Annabell *annabell, int rwd_act, int acq_act, int el_act) {
 int ExecuteAct(Annabell *annabell, Monitor *Mon, int rwd_act, int acq_act, int el_act) {
   SetAct(annabell, rwd_act, acq_act, el_act);
   Mon->Print();
-  if (flags->VerboseFlag) Mon->PrintRwdAct();
+  if (annabell->flags->VerboseFlag) Mon->PrintRwdAct();
   annabell->StActRwdUpdate();
-  if (flags->VerboseFlag) {Mon->PrintElActFL(); Mon->PrintElAct();}
+  if (annabell->flags->VerboseFlag) {Mon->PrintElActFL(); Mon->PrintElAct();}
   annabell->Update();
 
   return 0;
@@ -216,16 +213,16 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     GetInputPhrase(annabell, Mon, target_phrase);
     ExecuteAct(annabell, Mon, NULL_ACT, MEM_PH, NULL_ACT);
     Display.Print(" >>> End context\n");
-    flags->StartContextFlag=true;
+    annabell->flags->StartContextFlag=true;
 
     // answer time
-    if (flags->AnswerTimeFlag && flags->AnswerTimeUpdate && flags->AnswerTimePhrase!="") {
+    if (annabell->flags->AnswerTimeFlag && annabell->flags->AnswerTimeUpdate && annabell->flags->AnswerTimePhrase!="") {
       struct timespec clk0, clk1;
       GetRealTime(&clk0);
 
-      flags->AnswerTimeUpdate=false;
+      annabell->flags->AnswerTimeUpdate=false;
       ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
-      GetInputPhrase(annabell, Mon, flags->AnswerTimePhrase);
+      GetInputPhrase(annabell, Mon, annabell->flags->AnswerTimePhrase);
       Exploitation(annabell, Mon, 1);
 
       GetRealTime(&clk1);
@@ -237,13 +234,13 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       fclose(at_fp);
     }
     // auto save links
-    if (flags->AutoSaveLinkFlag) {
+    if (annabell->flags->AutoSaveLinkFlag) {
       double link_num = (double)annabell->ElActfSt->CountSparseInputLinks();
-      int index = (int)(link_num/flags->AutoSaveLinkStep);
-      if (index>flags->AutoSaveLinkIndex) {
-    	  flags->AutoSaveLinkIndex = index;
+      int index = (int)(link_num/annabell->flags->AutoSaveLinkStep);
+      if (index>annabell->flags->AutoSaveLinkIndex) {
+    	  annabell->flags->AutoSaveLinkIndex = index;
 	char filename[20];
-	sprintf(filename, "links_%d.dat", flags->AutoSaveLinkIndex);
+	sprintf(filename, "links_%d.dat", annabell->flags->AutoSaveLinkIndex);
 	FILE *fp=fopen(filename, "wb");
 	Mon->SaveWM(fp);
 	if (annabell->MemPh->HighVect.size()!=1) {
@@ -289,7 +286,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
   if (buf[0]!='.' || (buf[1]=='.' && buf[2]=='.')) {
     // if token does not start with "." or if token is "..."
     // input line is a phrase, not a command
-    if (flags->SpeakerFlag) Display.Print("*" + flags->SpeakerName + ":\t"); //("*TEA:\t");
+    if (annabell->flags->SpeakerFlag) Display.Print("*" + annabell->flags->SpeakerName + ":\t"); //("*TEA:\t");
     Display.Print(input_line+"\n");
     ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
     GetInputPhrase(annabell, Mon, input_line);
@@ -309,7 +306,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       Display.Warning("syntax error.");
       return 1;
     }
-    flags->StartContextFlag=false;
+    annabell->flags->StartContextFlag=false;
 
     return 0;
   }
@@ -447,7 +444,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, NULL_ACT);
     ExplorationApprove(annabell, Mon);
     ExplorationPhaseIdx=0;
-    flags->AnswerTimeUpdate=true;
+    annabell->flags->AnswerTimeUpdate=true;
 
     return 0;
   }
@@ -498,7 +495,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       for(unsigned int itk=2; itk<input_token.size(); itk++) {
 	target_phrase = target_phrase + " " + input_token[itk];
       }
-      if (flags->AnswerTimePhrase=="")  flags->AnswerTimePhrase = target_phrase;
+      if (annabell->flags->AnswerTimePhrase=="")  annabell->flags->AnswerTimePhrase = target_phrase;
       ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
       GetInputPhrase(annabell, Mon, target_phrase);
     }
@@ -524,7 +521,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       for(unsigned int itk=2; itk<input_token.size(); itk++) {
 	target_phrase = target_phrase + " " + input_token[itk];
       }
-      if (flags->AnswerTimePhrase=="")  flags->AnswerTimePhrase = target_phrase;
+      if (annabell->flags->AnswerTimePhrase=="")  annabell->flags->AnswerTimePhrase = target_phrase;
       ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
       GetInputPhrase(annabell, Mon, target_phrase);
     }
@@ -715,7 +712,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, NULL_ACT);
     ExplorationApprove(annabell, Mon);
     ExplorationPhaseIdx=0;
-    flags->AnswerTimeUpdate=true;
+    annabell->flags->AnswerTimeUpdate=true;
 
     return 0;
   }
@@ -1065,12 +1062,12 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       return 1;
     }
     if (input_token[1]=="off") {
-    	flags->SpeakerFlag = false;
+    	annabell->flags->SpeakerFlag = false;
       return 0;
     }
     else {
-    	flags->SpeakerName = input_token[1];
-    	flags->SpeakerFlag = true;
+    	annabell->flags->SpeakerName = input_token[1];
+    	annabell->flags->SpeakerFlag = true;
       return 0;
     }
     return 1;
@@ -1087,7 +1084,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     FILE *at_fp=fopen("answer_time.dat", "w");
     fclose(at_fp);
 
-    flags->AnswerTimeFlag = true;
+    annabell->flags->AnswerTimeFlag = true;
 
     return 0;
   }
@@ -1105,7 +1102,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     GetRealTime(&clk0);
     
     ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
-    GetInputPhrase(annabell, Mon, flags->AnswerTimePhrase);
+    GetInputPhrase(annabell, Mon, annabell->flags->AnswerTimePhrase);
     Exploitation(annabell, Mon, 1);
 
     GetRealTime(&clk1);
@@ -1127,9 +1124,9 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       Display.Warning("syntax error.");
       return 1;
     }
-    flags->AutoSaveLinkFlag = true;
+    annabell->flags->AutoSaveLinkFlag = true;
     double link_num = (double)annabell->ElActfSt->CountSparseInputLinks();
-    flags->AutoSaveLinkIndex = (int)(link_num/flags->AutoSaveLinkStep);
+    annabell->flags->AutoSaveLinkIndex = (int)(link_num/annabell->flags->AutoSaveLinkStep);
 
     return 0;
   }
@@ -1143,11 +1140,11 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       return 1;
     }
     if (input_token[1]=="off") {
-    	flags->PeriodFlag = false;
+    	annabell->flags->PeriodFlag = false;
       return 0;
     }
     else if (input_token[1]=="on") {
-    	flags->PeriodFlag = true;
+    	annabell->flags->PeriodFlag = true;
       return 0;
     }
     else {
@@ -1267,8 +1264,8 @@ int GetInputPhrase(Annabell *annabell, Monitor *Mon, string input_phrase)
 int BuildAs(Annabell *annabell, Monitor *Mon)
 {
   //cout << "ok2\n";
-  if (flags->StartContextFlag) {
-	  flags->StartContextFlag = false;
+  if (annabell->flags->StartContextFlag) {
+	  annabell->flags->StartContextFlag = false;
     annabell->SetStartPhFlag->Nr[0]->O = 1;
   }
   else annabell->SetStartPhFlag->Nr[0]->O = 0;
@@ -1295,8 +1292,8 @@ int BuildAsTest(Annabell *annabell, Monitor *Mon)
   int PhI;
 
   annabell->SetMode(ASSOCIATE);
-  if (flags->StartContextFlag) {
-	  flags->StartContextFlag = false;
+  if (annabell->flags->StartContextFlag) {
+	  annabell->flags->StartContextFlag = false;
     ExecuteAct(annabell, Mon, NULL_ACT, SET_START_PH, NULL_ACT);
   }
   else ExecuteAct(annabell, Mon, NULL_ACT, MEM_PH, NULL_ACT);
@@ -1569,12 +1566,12 @@ string Exploitation(Annabell *annabell, Monitor *Mon, int n_iter)
 
     //if (annabell->ElAct->Default->Nr[0]->O<0.5)
     Mon->Print();
-    if (flags->VerboseFlag) Mon->PrintRwdAct();
+    if (annabell->flags->VerboseFlag) Mon->PrintRwdAct();
     //int prev_act=Mon->GetElAct(); // temporary
     annabell->StActRwdUpdate();
     //int next_act=Mon->GetElAct(); // temporary
-    if (flags->VerboseFlag) Mon->PrintElActFL();
-    if (flags->VerboseFlag) Mon->PrintElAct();
+    if (annabell->flags->VerboseFlag) Mon->PrintElActFL();
+    if (annabell->flags->VerboseFlag) Mon->PrintElAct();
 
     annabell->Update();
 
@@ -1628,9 +1625,9 @@ string Exploitation(Annabell *annabell, Monitor *Mon, int n_iter)
   } while (annabell->EndExploitFlag->Nr[0]->O==0);
 
   annabell->ExploitUpdate();
-  if (flags->SpeakerFlag) Display.Print("*SYS:\t");
+  if (annabell->flags->SpeakerFlag) Display.Print("*SYS:\t");
   Display.Print(BestPhrase);
-  if (flags->PeriodFlag) Display.Print(" . \n");
+  if (annabell->flags->PeriodFlag) Display.Print(" . \n");
   else Display.Print("\n");
   annabell->SetMode(NULL_MODE);
 
@@ -1741,9 +1738,9 @@ string ExploitationTest(Annabell *annabell, Monitor *Mon, int n_iter)
     if (iac==Nac) Display.Warning("Exploitation number of actions >= " +
 				  toStr(Nac) + ". Exiting\n");
   }
-  if (flags->SpeakerFlag) Display.Print("*SYS:\t");
+  if (annabell->flags->SpeakerFlag) Display.Print("*SYS:\t");
   Display.Print(BestPhrase);
-  if (flags->PeriodFlag) Display.Print(" . \n");
+  if (annabell->flags->PeriodFlag) Display.Print(" . \n");
   else Display.Print("\n");
 
   annabell->SetMode(NULL_MODE);
@@ -1780,9 +1777,9 @@ int TargetExploration(Annabell *annabell, Monitor *Mon, string name, string targ
 
     //if (annabell->ElAct->Default->Nr[0]->O<0.5)
     Mon->Print();
-    if (flags->VerboseFlag) Mon->PrintRwdAct();
+    if (annabell->flags->VerboseFlag) Mon->PrintRwdAct();
     annabell->StActRwdUpdate();
-    if (flags->VerboseFlag) {Mon->PrintElActFL(); Mon->PrintElAct();}
+    if (annabell->flags->VerboseFlag) {Mon->PrintElActFL(); Mon->PrintElAct();}
 
     annabell->Update();
 

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -111,25 +111,8 @@ int CheckTryLimit(int i) {
   return 0;
 }
 
-int SetAct(Annabell *annabell, int acq_act, int el_act) {
-  annabell->AcqAct->Fill((int*)v_acq_act[acq_act]);
-  annabell->ElActFL->Fill((int*)v_el_act[el_act]);
-  annabell->ElAct->Fill((int*)v_el_act[el_act]);
-
-  return 0;
-}
-
-int SetAct(Annabell *annabell, int rwd_act, int acq_act, int el_act) {
-  annabell->RwdAct->Fill((int*)v_rwd_act[rwd_act]);
-  annabell->AcqAct->Fill((int*)v_acq_act[acq_act]);
-  annabell->ElActFL->Fill((int*)v_el_act[el_act]);
-  annabell->ElAct->Fill((int*)v_el_act[el_act]);
-
-  return 0;
-}
-
 int ExecuteAct(Annabell *annabell, Monitor *Mon, int rwd_act, int acq_act, int el_act) {
-  SetAct(annabell, rwd_act, acq_act, el_act);
+  annabell->SetAct(rwd_act, acq_act, el_act);
   Mon->Print();
   if (annabell->flags->VerboseFlag) Mon->PrintRwdAct();
   annabell->StActRwdUpdate();
@@ -268,7 +251,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       }
     }
     // added 5/01/2013
-    SetAct(annabell, START_ST_A, NULL_ACT, NULL_ACT);
+    annabell->SetAct(START_ST_A, NULL_ACT, NULL_ACT);
     annabell->StActRwdUpdate();
     Mon->Print();
     annabell->Update();
@@ -437,7 +420,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     //annabell->EPhaseI->Clear();
 
     // added 5/01/2013
-    SetAct(annabell, START_ST_A, NULL_ACT, NULL_ACT);
+    annabell->SetAct(START_ST_A, NULL_ACT, NULL_ACT);
     annabell->StActRwdUpdate();
     Mon->Print();
     annabell->Update();
@@ -473,7 +456,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     //annabell->EPhaseI->Clear();
 
     // added 5/01/2013
-    SetAct(annabell, START_ST_A, NULL_ACT, NULL_ACT);
+    annabell->SetAct(START_ST_A, NULL_ACT, NULL_ACT);
     annabell->StActRwdUpdate();
     Mon->Print();
     annabell->Update();
@@ -705,7 +688,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
     int n_iter=annabell->ElActfSt->K;
     Reward(annabell, Mon, 0, n_iter);
 
-    SetAct(annabell, START_ST_A, NULL_ACT, NULL_ACT);
+    annabell->SetAct(START_ST_A, NULL_ACT, NULL_ACT);
     annabell->StActRwdUpdate();
     Mon->Print();
     annabell->Update();
@@ -784,7 +767,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       Display.Warning("syntax error.");
       return 1;
     }
-    SetAct(annabell, NULL_ACT, NULL_ACT);
+    annabell->SetAct(NULL_ACT, NULL_ACT);
     annabell->Update();
     return 0;
   }
@@ -822,7 +805,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
       Display.Warning("unknown action name.");
       return 1;
     }
-    SetAct(annabell, NULL_ACT, iact);
+    annabell->SetAct(NULL_ACT, iact);
     annabell->Update();
     Mon->Print();
     return 0;
@@ -1175,7 +1158,7 @@ int GetInputPhraseTest(Annabell *annabell, Monitor *Mon, string input_phrase)
   annabell->W->Fill(vin);
   ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
 
-  SetAct(annabell, ACQ_W, NULL_ACT);
+  annabell->SetAct(ACQ_W, NULL_ACT);
 
   string buf; // Have a buffer string
   stringstream ss(input_phrase); // Insert the string into a stream
@@ -1194,7 +1177,7 @@ int GetInputPhraseTest(Annabell *annabell, Monitor *Mon, string input_phrase)
   for (int ic=0; ic<WSize; ic++) vin[ic]=0;
   annabell->W->Fill(vin);
 
-  SetAct(annabell, NULL_ACT, W_FROM_WK);
+  annabell->SetAct(NULL_ACT, W_FROM_WK);
   Mon->Print();
   annabell->Update();
 
@@ -1299,12 +1282,12 @@ int BuildAsTest(Annabell *annabell, Monitor *Mon)
   else ExecuteAct(annabell, Mon, NULL_ACT, MEM_PH, NULL_ACT);
 
   int SkipW = 0;
-  SetAct(annabell, NULL_ACT, W_FROM_WK);
+  annabell->SetAct(NULL_ACT, W_FROM_WK);
   Mon->Print();
   annabell->Update();
   while (SkipW<PhSize && annabell->InPhB->RowDefault->Nr[SkipW]->O<0.5) {
     for (PhI=-1; PhI<SkipW; PhI++) {
-      SetAct(annabell, NEXT_AS_W, NULL_ACT);
+    	annabell->SetAct(NEXT_AS_W, NULL_ACT);
       Mon->Print();
       //annabell->ActUpdate(); //just to save time in place of Update
       annabell->Update();
@@ -1312,17 +1295,17 @@ int BuildAsTest(Annabell *annabell, Monitor *Mon)
     ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_WG);
     for (int WGI=0; WGI<3 && PhI<PhSize
 	   && annabell->InPhB->RowDefault->Nr[PhI]->O<0.5; WGI++) {
-      SetAct(annabell, BUILD_AS, NULL_ACT);
+    	annabell->SetAct(BUILD_AS, NULL_ACT);
       Mon->Print();
       annabell->Update();
 
-      SetAct(annabell, NEXT_AS_W, NULL_ACT);
+      annabell->SetAct(NEXT_AS_W, NULL_ACT);
       Mon->Print();
       annabell->Update();
       PhI++;
     }
     SkipW++;
-    SetAct(annabell, NULL_ACT, W_FROM_WK);
+    annabell->SetAct(NULL_ACT, W_FROM_WK);
     Mon->Print();
     annabell->Update();
   }
@@ -1341,7 +1324,7 @@ int MoreRetrAsSlow(Annabell *annabell, Monitor *Mon)
   int next_act, Nas=20;
   for (int i=0; i<Nas; i++) {
     //cout << "MoreRetrAs " << i << endl;
-    SetAct(annabell, NULL_ACT, RETR_AS);
+	  annabell->SetAct(NULL_ACT, RETR_AS);
     annabell->Update();
     //Mon->Print();
     ExecuteAct(annabell, Mon, RETR_EL_A, NULL_ACT, NULL_ACT);
@@ -1415,7 +1398,7 @@ int MoreRetrAs(Annabell *annabell, Monitor *Mon)
   int next_act, Nas=20;
   for (int i=0; i<Nas; i++) {
     //cout << "MoreRetrAs " << i << endl;
-    SetAct(annabell, NULL_ACT, RETR_AS);
+	  annabell->SetAct(NULL_ACT, RETR_AS);
     annabell->Update();
     //Mon->Print();
     ExecuteAct(annabell, Mon, RETR_EL_A, NULL_ACT, NULL_ACT);
@@ -1436,12 +1419,12 @@ int ExplorationRetry(Annabell *annabell, Monitor *Mon)
   //cout << "StoredStActI: " << annabell->StoredStActI->HighVect[0] << endl;
   //cout << "StActI before: " << annabell->StActI->HighVect[0] << endl;
   //Mon->Print();
-  SetAct(annabell, RETR_SAI, NULL_ACT, NULL_ACT);
+  annabell->SetAct(RETR_SAI, NULL_ACT, NULL_ACT);
   annabell->StActRwdUpdate();
   //cout << "StActI after: " << annabell->StActI->HighVect[0] << endl;
-  SetAct(annabell, RETR_ST_A, NULL_ACT, NULL_ACT);
+  annabell->SetAct(RETR_ST_A, NULL_ACT, NULL_ACT);
   annabell->StActRwdUpdate();
-  SetAct(annabell, RETR_SAI, NULL_ACT, NULL_ACT);
+  annabell->SetAct(RETR_SAI, NULL_ACT, NULL_ACT);
   annabell->StActRwdUpdate();
   //Mon->Print();
   annabell->RetrStActIFlag->Nr[0]->O=0;
@@ -1466,23 +1449,23 @@ int RewardTest(Annabell *annabell, Monitor *Mon, int partial_flag, int n_iter)
 {
   annabell->SetMode(REWARD);
 
-  SetAct(annabell, STORE_ST_A, NULL_ACT, FLUSH_OUT);
+  annabell->SetAct(STORE_ST_A, NULL_ACT, FLUSH_OUT);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();
 
-  SetAct(annabell, STORE_ST_A, NULL_ACT, WG_OUT);
+  annabell->SetAct(STORE_ST_A, NULL_ACT, WG_OUT);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();
 
-  if (partial_flag!=0) SetAct(annabell, STORE_ST_A, NULL_ACT, CONTINUE);
-  else SetAct(annabell, STORE_ST_A, NULL_ACT, DONE);
+  if (partial_flag!=0) annabell->SetAct(STORE_ST_A, NULL_ACT, CONTINUE);
+  else annabell->SetAct(STORE_ST_A, NULL_ACT, DONE);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();
 
-  SetAct(annabell, STORE_ST_A, NULL_ACT, NULL_ACT);
+  annabell->SetAct(STORE_ST_A, NULL_ACT, NULL_ACT);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();
@@ -1490,13 +1473,13 @@ int RewardTest(Annabell *annabell, Monitor *Mon, int partial_flag, int n_iter)
   int LastStActI = GetStActIdx(annabell, Mon); //annabell->StActI
   for (int i=0; i<n_iter; i++) {
     //Mon->ModeMessage("Start State-Action Index\n");
-    SetAct(annabell, START_ST_A, NULL_ACT, NULL_ACT);
+	  annabell->SetAct(START_ST_A, NULL_ACT, NULL_ACT);
     annabell->StActRwdUpdate();
     Mon->Print();
     annabell->Update();
     for (int StActI=0; StActI<LastStActI-1; StActI++) {
       //Mon->ModeMessage("Retrieve and reward State-Action\n");
-      SetAct(annabell, RWD_ST_A, NULL_ACT, NULL_ACT);
+    	annabell->SetAct(RWD_ST_A, NULL_ACT, NULL_ACT);
       annabell->StActRwdUpdate();
       Mon->Print();
       annabell->Update();
@@ -1999,12 +1982,12 @@ int WorkingPhraseOut(Annabell *annabell, Monitor *Mon)
     //	if (Mon->OutStr[0]=="") break;
     //}
   }
-  SetAct(annabell, STORE_ST_A, NULL_ACT, FLUSH_OUT);
+  annabell->SetAct(STORE_ST_A, NULL_ACT, FLUSH_OUT);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();
 
-  SetAct(annabell, STORE_ST_A, NULL_ACT, WG_OUT);
+  annabell->SetAct(STORE_ST_A, NULL_ACT, WG_OUT);
   annabell->StActRwdUpdate();
   Mon->Print();
   annabell->Update();

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -190,9 +190,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, string input_line) {
 	buf = "";
 	while (ss >> buf1) { // split line in string tokens
 
-		if (buf1 == "an") {
-			buf1 = "a"; // take care of article
-		}
+		buf1 = CommandUtils::processArticle(buf1);
 
 		buf1 = CommandUtils::processPlural(buf1);
 


### PR DESCRIPTION
Hi, I've created a new class AnnabellFlags to encapsulate all global flags, and made it an instance member of Annabell itself. This cleans up the global namespace a little bit, preparing the field to refactor the command processing in annabell_main into different Command objects.

I've also moved two SetAct functions to convert them to Annabell instance methods, because they act only upon annabell's private properties anyway. 

This pull request also includes minor changes regarding CommandUtils.