### PR TITLE
Interface Command-related improvements

### DIFF
--- a/new_examples/classical_logic.txt
+++ b/new_examples/classical_logic.txt
@@ -1,0 +1,23 @@
+########################################
+# example by James Metz (Senior Scientist at Abbvie) and Bruno Golosio
+########################################
+# training example
+
+Barbie is a doll
+
+all doll -s are toy -s
+
+tell me a toy
+.wg /toy/all doll -s are toy -s/doll/
+.o //Barbie is a doll/Barbie/
+
+########################################
+# test example
+
+Plato is a human
+
+all human -s are creature -s
+
+tell me a creature
+.x
+

--- a/new_examples/classical_logic_irregular.txt
+++ b/new_examples/classical_logic_irregular.txt
@@ -1,0 +1,28 @@
+########################################
+# example by James Metz (Senior Scientist at Abbvie) and Bruno Golosio
+########################################
+# training example
+
+the plural for mouse is mice
+
+Mickey is a mouse
+
+all mice are animal -s
+
+tell me an animal
+.wg /animal/all mice are animal -s/mice/
+.wg //the plural for mouse is mice/mouse/
+.o //Mickey is a mouse/Mickey/
+
+########################################
+# test example
+
+the plural for man is men
+
+Socrates is a man
+
+all men are mortal
+
+tell me a mortal
+.x
+

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include "CommandConstants.h"
 
 using namespace sizes;
 
@@ -112,15 +113,26 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 		input_token.push_back(buf);
 	}
 
-	if (simplify(annabell, Mon, Display, clk0, clk1, input_token)) {
-		return 0;
+	if (input_token.size() >= 2
+			&& (CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD)
+					|| CommandUtils::startsWith(input_token[0], REWARD_CMD)
+					|| CommandUtils::startsWith(input_token[0], PARTIAL_REWARD_CMD)
+					|| CommandUtils::startsWith(input_token[0], PUSH_GOAL_CMD)
+					|| CommandUtils::startsWith(input_token[0], PHRASE_CMD))) {
+
+		bool endProcessing;
+		endProcessing = simplify(annabell, Mon, Display, clk0, clk1, input_token);
+
+		if (endProcessing) {
+			return 0;
+		}
 	}
 
   string target_phrase;
 
   buf = input_token[0];
   ////////////////////////////////////////
-  if (buf[0]=='#') { // input line is a comment
+  if (buf[0] == COMMENT_CMD) { // input line is a comment
     Display->Print(input_line+"\n");
     return 0;
   }
@@ -141,9 +153,9 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Exits the program or the current input file
   ////////////////////////////////////////
-  if (buf==".quit" || buf==".q") return 2; // quit
+  if (buf == QUIT_CMD_LONG || buf == QUIT_CMD) return 2; // quit
   ////////////////////////////////////////
-  else if (buf==".continue_context" || buf==".cctx") { // continue context
+  else if (buf == CONTINUE_CONTEXT_CMD_LONG || buf == CONTINUE_CONTEXT_CMD) { // continue context
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;
@@ -155,7 +167,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Suggests a phrase to be retrieved by the association process.
   ////////////////////////////////////////
- else if (buf==".phrase" || buf==".ph") { // suggest a phrase
+ else if (buf == PHRASE_CMD_LONG || buf == PHRASE_CMD) { // suggest a phrase
     if (input_token.size()<2) {
       Display->Warning("a phrase should be provided as argument.");
       return 1;
@@ -174,7 +186,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Suggests a word group to be extracted from the working phrase.
   ////////////////////////////////////////
-  else if (buf==".word_group" || buf==".wg") { // suggest a group of words
+  else if (buf == WORD_GROUP_CMD_LONG || buf == WORD_GROUP_CMD) { // suggest a group of words
     if (input_token.size()<2) {
       //Display->Warning("a word group should be provided as argument.");
       //return 1;
@@ -198,7 +210,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Searches a phrase in the current context of the working phrase
   // starting from the beginning of the context
   ////////////////////////////////////////
-  else if (buf==".search_context" || buf==".sctx") { //search phrase in context
+  else if (buf == SEARCH_CONTEXT_CMD_LONG || buf == SEARCH_CONTEXT_CMD) { //search phrase in context
     if (input_token.size()<2) {
       Display->Warning("a phrase should be provided as argument.");
       return 1;
@@ -218,7 +230,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Searches a phrase in the current context of the working phrase
   // starting from the phrase next to the working phrase
   ////////////////////////////////////////
-  else if (buf==".continue_search_context" || buf==".csctx") {
+  else if (buf == CONTINUE_SEARCH_CONTEXT_CMD_LONG || buf == CONTINUE_SEARCH_CONTEXT_CMD) {
     //search phrase in context
     if (input_token.size()<2) {
       Display->Warning("a phrase should be provided as argument.");
@@ -238,7 +250,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Copies the input phrase to the working phrase.
   ////////////////////////////////////////
-  else if (buf==".retrieve_input_phrase" || buf==".rip") { // back to input
+  else if (buf == RETRIEVE_INPUT_PHRASE_CMD_LONG || buf == RETRIEVE_INPUT_PHRASE_CMD) { // back to input
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -258,7 +270,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Sends the word group to output and produces a (conclusive) reward
   // for the past state-action sequence.
   ////////////////////////////////////////
-  else if (buf==".reward" || buf==".rw") { // reward
+  else if (buf == REWARD_CMD_LONG || buf == REWARD_CMD2) { // reward
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;
@@ -294,7 +306,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Sends the word group to output and produces a partial reward
   // for the past state-action sequence.
   ////////////////////////////////////////
-  else if (buf==".partial_reward" || buf==".prw") { // partial reward
+  else if (buf == PARTIAL_REWARD_CMD_LONG || buf == PARTIAL_REWARD_CMD2) { // partial reward
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;
@@ -331,7 +343,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // phrase. Without argument, the exploitation is related to the previous
   // input phrase.
   ////////////////////////////////////////
-  else if (buf==".exploit" || buf==".x") { // exploitation
+  else if (buf == EXPLOIT_CMD_LONG || buf == EXPLOIT_CMD) { // exploitation
     if (input_token.size()>1) {
       target_phrase = input_token[1];
       for(unsigned int itk=2; itk<input_token.size(); itk++) {
@@ -354,7 +366,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // an appropriate output phrase. Without argument, the exploitation is
   // related to the previous input phrase.
   ////////////////////////////////////////
-  else if (buf==".clean_exploit" || buf==".cx") { // clean exploitation
+  else if (buf == CLEAN_EXPLOIT_CMD_LONG || buf == CLEAN_EXPLOIT_CMD) { // clean exploitation
     for (int i=0; i<5; i++)
       ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, DROP_GL);
 
@@ -380,7 +392,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // phrase with an appropriate output phrase. Without argument, the
   // exploitation is related to the previous input phrase.
   ////////////////////////////////////////
-  else if (buf==".exploit_random" || buf==".xr") { // random exploitation
+  else if (buf == EXPLOIT_RANDOM_CMD_LONG || buf == EXPLOIT_RANDOM_CMD) { // random exploitation
     if (input_token.size()>1) {
       target_phrase = input_token[1];
       for(unsigned int itk=2; itk<input_token.size(); itk++) {
@@ -402,7 +414,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Starts an exploitation phase.
   // The output phrase is memorized by the system.
   ////////////////////////////////////////
-  else if (buf==".exploit_memorize" || buf==".xm") { //exploitation-memorization
+  else if (buf == EXPLOIT_MEMORIZE_CMD_LONG || buf == EXPLOIT_MEMORIZE_CMD) { //exploitation-memorization
     if (input_token.size()>1) {
       target_phrase = input_token[1];
       for(unsigned int itk=2; itk<input_token.size(); itk++) {
@@ -426,7 +438,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
  // Analogous to .x, but it iterates the exploitation process n_iter times
  // and selects the best output phrase.
  ////////////////////////////////////////
-  else if (buf==".best_exploit"|| buf== ".bx") { // best exploitation
+  else if (buf == BEST_EXPLOIT_CMD_LONG|| buf == BEST_EXPLOIT_CMD) { // best exploitation
     if (input_token.size()<3) {
       Display->Warning("n. of iterations and a phrase should be provided");
       Display->Warning("as argument in the current version.");
@@ -464,7 +476,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Insert the working phrase and the current word group in the top of the
   // goal stack
   ////////////////////////////////////////
-  else if (buf==".push_goal" || buf==".pg") { // push goal
+  else if (buf == PUSH_GOAL_CMD_LONG || buf == PUSH_GOAL_CMD) { // push goal
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -487,7 +499,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Removes the goal phrase and the goal word group from the top
   // of the goal stack
   ////////////////////////////////////////
-  else if (buf==".drop_goal" || buf==".dg") { // drop goal
+  else if (buf == DROP_GOAL_CMD_LONG || buf == DROP_GOAL_CMD) { // drop goal
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -505,7 +517,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Copies the goal phrase from the top of the goal stack to the
   // working phrase
   ////////////////////////////////////////
-  else if (buf==".get_goal_phrase" || buf==".ggp") { // get goal phrase
+  else if (buf == GET_GOAL_PHRASE_CMD_LONG || buf == GET_GOAL_PHRASE_CMD) { // get goal phrase
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -520,7 +532,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   }
 
   ////////////////////////////////////////
-  else if (buf==".working_phrase_out" || buf==".wpo") { // working phrase out
+  else if (buf == WORKING_PHRASE_OUT_CMD_LONG || buf == WORKING_PHRASE_OUT_CMD) { // working phrase out
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -535,7 +547,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // current word, and all subsequent phrases of the same context until the
   // end of the context itself.
   ////////////////////////////////////////
-  else if (buf==".sentence_out" || buf==".snto") { // sentence out
+  else if (buf == SENTENCE_OUT_CMD_LONG || buf == SENTENCE_OUT_CMD) { // sentence out
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -562,7 +574,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Loads phrases and/or commands from the file file_name.
   ////////////////////////////////////////
-  else if (buf==".file" || buf==".f") { // read phrases/commands from file
+  else if (buf == FILE_CMD_LONG || buf == FILE_CMD) { // read phrases/commands from file
     if (input_token.size()<2) {
       Display->Warning("a file name should be provided as argument.");
       return 1;
@@ -583,7 +595,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   // Gets the input phrase provided as argument without building the
   // associations between the word groups and the phrase.
   ////////////////////////////////////////
-  else if (buf==".get_input_phrase" || buf==".gi") { // get input phrase
+  else if (buf == GET_INPUT_PHRASE_CMD_LONG || buf == GET_INPUT_PHRASE_CMD) { // get input phrase
     if (input_token.size()<2) {
       Display->Warning("a phrase should be provided as argument.");
       return 1;
@@ -599,7 +611,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Builds the associations between the word groups and the working phrase.
   ////////////////////////////////////////
-  else if (buf==".build_association" || buf==".ba") { // build association
+  else if (buf == BUILD_ASSOCIATION_CMD_LONG || buf == BUILD_ASSOCIATION_CMD) { // build association
     if (input_token.size()!=1) {
       Display->Warning("no arguments should be provided.");
       return 1;
@@ -621,7 +633,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Executes a system update with a NULL action
   ////////////////////////////////////////
-  else if (buf==".null" || buf==".n") { // null action
+  else if (buf == NULL_CMD_LONG || buf == NULL_CMD) { // null action
     if (input_token.size()!=1) {
       Display->Warning("syntax error.");
       return 1;
@@ -634,7 +646,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Sends a command to the monitor
   ////////////////////////////////////////
-  else if (buf==".monitor" || buf==".m") { // send a command to the monitor
+  else if (buf == MONITOR_CMD_LONG || buf == MONITOR_CMD) { // send a command to the monitor
     if (input_token.size()<2) {
       Display->Warning("a monitor command should be provided as argument.");
       return 1;
@@ -651,7 +663,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Executes single elaboration action
   ////////////////////////////////////////
-  else if (buf==".action" || buf==".a") { // executes single elaboration action
+  else if (buf == ACTION_CMD_LONG || buf == ACTION_CMD) { // executes single elaboration action
     if (input_token.size()!=2) {
       Display->Warning("syntax error.");
       return 1;
@@ -673,7 +685,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Displays the execution time
   ////////////////////////////////////////
-  else if (buf==".time" || buf==".t") { // time
+  else if (buf == TIME_CMD_LONG || buf == TIME_CMD) { // time
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -713,7 +725,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Displays some statistical information
   ////////////////////////////////////////
-  else if (buf==".stat") { // statistic
+  else if (buf == STAT_CMD) { // statistic
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -761,7 +773,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Starts CUDA version of exploitation mode
   ////////////////////////////////////////
-  else if (buf==".cuda" || buf==".cu") { // time
+  else if (buf == CUDA_CMD_LONG || buf == CUDA_CMD) { // time
     if (input_token.size()>1) {
       Display->Warning("syntax error.");
       return 1;
@@ -780,7 +792,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Saves all variable-weight links to a file
   ////////////////////////////////////////
-  else if (buf==".save") { // save links
+  else if (buf == SAVE_CMD) { // save links
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;
@@ -819,7 +831,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Loads all variable-weight links from a file
   ////////////////////////////////////////
-  else if (buf==".load") { // load links
+  else if (buf == LOAD_CMD) { // load links
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;
@@ -870,12 +882,12 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Writes the output to a log file
   ////////////////////////////////////////
-  else if (buf==".logfile") { // write output to a log file
+  else if (buf == LOGFILE_CMD) { // write output to a log file
     if (input_token.size()<2) {
       Display->Warning("a file name or off should be provided as argument.");
       return 1;
     }
-    if (input_token[1]=="off" && Display->LogFileFlag) {
+    if (input_token[1] == LOGFILE_OFF && Display->LogFileFlag) {
       Mon->Display.LogFileFlag = Display->LogFileFlag = false;
       Display->LogFile->close();
       return 0;
@@ -898,7 +910,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Displays the speaker names using the CHAT format (3 characters)
   ////////////////////////////////////////
-  else if (buf==".speaker") { // display the name of the speaker
+  else if (buf == SPEAKER_CMD) { // display the name of the speaker
     if (input_token.size()<2) {
       Display->Warning("a speaker name or off should be provided as argument.");
       return 1;
@@ -918,7 +930,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Records the answer time
   ////////////////////////////////////////
-  else if (buf==".answer_time" || buf==".at") { // record answer time
+  else if (buf == ANSWER_TIME_CMD_LONG || buf == ANSWER_TIME_CMD) { // record answer time
     if (input_token.size()!=1) {
       Display->Warning("syntax error.");
       return 1;
@@ -934,7 +946,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Evaluates the answer time
   ////////////////////////////////////////
-  else if (buf==".evaluate_answer_time" || buf==".eat") {//evaluate answer time
+  else if (buf == EVALUATE_ANSWER_TIME_CMD_LONG || buf == EVALUATE_ANSWER_TIME_CMD) {//evaluate answer time
     if (input_token.size()!=1) {
       Display->Warning("syntax error.");
       return 1;
@@ -961,7 +973,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Periodically save variable-link weights in files with progressive numbers
   ////////////////////////////////////////
-  else if (buf==".auto_save_links" || buf==".asl") { // autosave links
+  else if (buf == AUTO_SAVE_LINKS_CMD_LONG || buf == AUTO_SAVE_LINKS_CMD) { // autosave links
     if (input_token.size()!=1) {
       Display->Warning("syntax error.");
       return 1;
@@ -976,16 +988,16 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Displays a period at the end of the output sentences
   ////////////////////////////////////////
-  else if (buf==".period") { // display a period at the end of output sentences
+  else if (buf == PERIOD_CMD) { // display a period at the end of output sentences
     if (input_token.size()<2) {
       Display->Warning("on or off should be provided as argument.");
       return 1;
     }
-    if (input_token[1]=="off") {
+    if (input_token[1] == PERIOD_OFF) {
     	annabell->flags->PeriodFlag = false;
       return 0;
     }
-    else if (input_token[1]=="on") {
+    else if (input_token[1] == PERIOD_ON) {
     	annabell->flags->PeriodFlag = true;
       return 0;
     }

--- a/src/CommandConstants.h
+++ b/src/CommandConstants.h
@@ -1,0 +1,243 @@
+/*
+ * CommandConstants.h
+ *
+ *  Created on: Jan 17, 2016
+ *      Author: jpp
+ */
+
+#ifndef SRC_COMMANDCONSTANTS_H_
+#define SRC_COMMANDCONSTANTS_H_
+
+#include <string>
+
+using namespace std;
+
+/** Suggests a phrase to be retrieved by the association process */
+const string PHRASE_CMD = ".ph";
+const string PHRASE_CMD_LONG = ".phrase";
+
+/** Suggests a word group to be extracted from the working phrase */
+const string WORD_GROUP_CMD = ".wg";
+const string WORD_GROUP_CMD_LONG = ".word_group";
+
+/** Sends the word group to output and produces a partial reward for the past state-action sequence */
+const string PARTIAL_REWARD_CMD = ".po";
+const string PARTIAL_REWARD_CMD_LONG = ".partial_reward";
+const string PARTIAL_REWARD_CMD2 = ".prw";
+
+/** Sends the word group to output and produces a (conclusive) reward for the past state-action sequence */
+const string REWARD_CMD = ".o";
+const string REWARD_CMD_LONG = ".reward";
+const string REWARD_CMD2 = ".rw";
+
+/**
+ * Starts an exploitation phase.
+ * At the end of this phase, the system is expected to respond to the input phrase with an appropriate output phrase.
+ * Without argument, the exploitation is related to the previous input phrase.
+ */
+const string EXPLOIT_CMD = ".x";
+const string EXPLOIT_CMD_LONG = ".exploit";
+
+/**
+ * Loads phrases and/or commands from the specified file path
+ */
+const string FILE_CMD = ".f";
+const string FILE_CMD_LONG = ".file";
+
+/**
+ * Clear the goal stack and starts an exploitation phase. At the end of this phase, the system is
+ * expected to respond to the input phrase with an appropriate output phrase. Without argument,
+ * the exploitation is related to the previous input phrase.
+ */
+const string CLEAN_EXPLOIT_CMD = ".cx";
+const string CLEAN_EXPLOIT_CMD_LONG = ".clean_exploit";
+
+/**
+ * Starts an exploitation phase using a random ordering for the WTA rule. At the end of this
+ * phase, the system is expected to respond to the input phrase with an appropriate output
+ * phrase. Without argument, the exploitation is related to the previous input phrase.
+ */
+const string EXPLOIT_RANDOM_CMD = ".xr";
+const string EXPLOIT_RANDOM_CMD_LONG = ".exploit_random";
+
+/**
+ * Starts an exploitation phase.
+ * The output phrase is memorized by the system.
+ */
+const string EXPLOIT_MEMORIZE_CMD = ".xm";
+const string EXPLOIT_MEMORIZE_CMD_LONG = ".exploit_memorize";
+
+/**
+ * Analogous to .x, but it iterates the exploitation process n_iter times and selects the best
+ * output phrase.
+ */
+const string BEST_EXPLOIT_CMD = ".bx";
+const string BEST_EXPLOIT_CMD_LONG = ".best_exploit";
+
+/**
+ * Insert the working phrase and the current word group in the top of the goal stack.
+ */
+const string PUSH_GOAL_CMD = ".pg";
+const string PUSH_GOAL_CMD_LONG = ".push_goal";
+
+/**
+ * Removes the goal phrase and the goal word group from the top of the goal stack.
+ */
+const string DROP_GOAL_CMD = ".dg";
+const string DROP_GOAL_CMD_LONG = ".drop_goal";
+
+/**
+ * Copies the goal phrase from the top of the goal stack to the working phrase.
+ */
+const string GET_GOAL_PHRASE_CMD = ".ggp";
+const string GET_GOAL_PHRASE_CMD_LONG = ".get_goal_phrase";
+
+/**
+ * Sends to the output the next part of the working phrase, after the current word, and all
+ * subsequent phrases of the same context until the end of the context itself.
+ */
+const string SENTENCE_OUT_CMD = ".snto";
+const string SENTENCE_OUT_CMD_LONG = ".sentence_out";
+
+/**
+ * Searches a phrase in the current context of the working phrase.
+ */
+const string SEARCH_CONTEXT_CMD = ".sctx";
+const string SEARCH_CONTEXT_CMD_LONG = ".search_context";
+
+/**
+ * TODO: undocumented command.
+ */
+const string CONTINUE_CONTEXT_CMD = ".cctx";
+const string CONTINUE_CONTEXT_CMD_LONG = ".continue_context";
+
+/**
+ * TODO: undocumented command.
+ */
+const string CONTINUE_SEARCH_CONTEXT_CMD = ".csctx";
+const string CONTINUE_SEARCH_CONTEXT_CMD_LONG = ".continue_search_context";
+
+/**
+ * TODO: undocumented command.
+ */
+const string WORKING_PHRASE_OUT_CMD = ".wpo";
+const string WORKING_PHRASE_OUT_CMD_LONG = ".working_phrase_out";
+
+/**
+ * Copies the input phrase to the working phrase.
+ */
+const string RETRIEVE_INPUT_PHRASE_CMD = ".rip";
+const string RETRIEVE_INPUT_PHRASE_CMD_LONG = ".retrieve_input_phrase";
+
+/**
+ * Gets the input phrase provided as argument without building the associations between the
+ * word groups and the phrase.
+ */
+const string GET_INPUT_PHRASE_CMD = ".gi";
+const string GET_INPUT_PHRASE_CMD_LONG = ".get_input_phrase";
+
+/**
+ * Builds the associations between the word groups and the working phrase.
+ */
+const string BUILD_ASSOCIATION_CMD = ".ba";
+const string BUILD_ASSOCIATION_CMD_LONG = ".build_association";
+
+/**
+ * Executes single elaboration action
+ */
+const string ACTION_CMD = ".a";
+const string ACTION_CMD_LONG = ".action";
+
+/**
+ * Displays the execution time
+ */
+const string TIME_CMD = ".t";
+const string TIME_CMD_LONG = ".time";
+
+/**
+ * Displays some statistical information.
+ */
+const string STAT_CMD = ".stat";
+
+/**
+ * Executes a system update with a NULL action.
+ */
+const string NULL_CMD = ".n";
+const string NULL_CMD_LONG = ".null";
+
+/**
+ * Sends a command to the monitor
+ */
+const string MONITOR_CMD = ".m";
+const string MONITOR_CMD_LONG = ".monitor";
+
+/**
+ * Saves all variable-weight links to a file.
+ */
+const string SAVE_CMD = ".save";
+
+/**
+ * Loads all variable-weight links from a file.
+ */
+const string LOAD_CMD = ".load";
+
+/**
+ * Writes the output to a log file.
+ */
+const string LOGFILE_CMD = ".logfile";
+
+/**
+ * Closes the log file.
+ */
+const string LOGFILE_OFF = "off";
+
+/**
+ * Displays the speaker names using the CHAT format.
+ */
+const string SPEAKER_CMD = ".speaker";
+
+/**
+ * Stops displaying the speaker names.
+ */
+const string SPEAKER_OFF = "off";
+
+/**
+ * Displays a period at the end of the output sentences.
+ */
+const string PERIOD_CMD = ".period";
+const string PERIOD_ON = "on";
+const string PERIOD_OFF = "off";
+
+/**
+ * Records the answer time.
+ */
+const string ANSWER_TIME_CMD = ".at";
+const string ANSWER_TIME_CMD_LONG = ".answer_time";
+
+/**
+ * Evaluates the answer time.
+ */
+const string EVALUATE_ANSWER_TIME_CMD = ".eat";
+const string EVALUATE_ANSWER_TIME_CMD_LONG = ".evaluate_answer_time";
+
+/**
+ * Periodically save variable-link weights in files with progressive numbers.
+ */
+const string AUTO_SAVE_LINKS_CMD = ".asl";
+const string AUTO_SAVE_LINKS_CMD_LONG = ".auto_save_links";
+
+/**
+ * exits the program or the current input file
+ */
+const string QUIT_CMD = ".q";
+const string QUIT_CMD_LONG = ".quit";
+
+const char COMMENT_CMD = '#';
+
+/**
+ * Starts CUDA version of exploitation mode
+ */
+const string CUDA_CMD = ".cu";
+const string CUDA_CMD_LONG = ".cuda";
+
+#endif /* SRC_COMMANDCONSTANTS_H_ */

--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -42,12 +42,42 @@ public:
 	}
 
 	/**
+	 * @returns true if input string starts with provided substring, false otherwise.
+	 */
+	static bool startsWith(string input, string subString) {
+		if (input.find(subString) == 0) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
 	 * @returns true if input string ends with provided character, false otherwise.
 	 */
 	static bool endsWith(string input, char character) {
 		int lastIndex = input.size() - 1;
 		return input[lastIndex] == character;
 	}
+
+	/**
+	 * @returns the input string, minus its last character
+	 */
+	static string removeTrailing(string input) {
+		return input.substr(0, input.size() - 1);
+	}
+
+	/**
+	 * @returns the input string, minus its last character, is such last character is equal to the character specified as second argument, or the unchanged specified string otherwise
+	 */
+	static string removeTrailing(string input, char character) {
+		if (CommandUtils::endsWith(input, character)) {
+			return input.substr(0, input.size() - 1);
+		} else {
+			return input;
+		}
+	}
+
 };
 
 #endif /* SRC_COMMANDUTILS_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = AnnabellFlags.h Command.h EmptyCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h
+annabellinclude_HEADERS = CommandConstants.h AnnabellFlags.h Command.h EmptyCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h
 
 bin_PROGRAMS = annabell
 

--- a/src/simplify.cc
+++ b/src/simplify.cc
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include "interface.h"
 #include "display.h" 
+#include "CommandUtils.h"
+#include "CommandConstants.h"
 
 using namespace std;
 
@@ -32,30 +34,19 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 
 bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* clk0, timespec* clk1, vector<string> input_token) {
 
-	string cmd, buf; // buffer string
+	//I think this is not necessary, because is comparing the LITERAL ".ph*" string, not finding strings that start with ".ph"
+	string cmd = CommandUtils::removeTrailing(input_token[0], '*');
+
 	string cmd_line; //command_line
-	bool push_flag;
 
-	if (input_token.size() <= 1) {
-		return false;
-	}
+	string buf; // buffer string
 
-	cmd = input_token[0];
 
-	if (cmd == ".wg*") {
-		cmd = ".wg";
-		push_flag = true;
-	} else if (cmd == ".po*") {
-		cmd = ".po";
-		push_flag = true;
-	} else if (cmd == ".o*") {
-		cmd = ".o";
-		push_flag = true;
-	} else {
-		push_flag = false;
-	}
+		bool push_flag = false;
 
-	if (input_token.size() >= 2 && (cmd == ".wg" || cmd == ".o" || cmd == ".po" || cmd == ".pg" || cmd == ".ph")) {
+		if (cmd == WORD_GROUP_CMD || cmd == REWARD_CMD || cmd == PARTIAL_REWARD_CMD) {
+			push_flag = true;
+		}
 		buf = input_token[1];
 
 		if (input_token.size() == 2 && buf[0] == '/') {
@@ -123,31 +114,31 @@ bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* 
 			}
 
 			// if working phrase must be stored and retrieved at the end
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".push_goal") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
 				return true;
 			}
 
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".ggp") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
 				return true;
 			}
 
 			if (s1b != "") { // if there is a second cue
 
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(".wg ") + s1b) == 2) {
+				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1b) == 2) {
 					return true;
 				}
 
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, ".push_goal") == 2) {
+				if (ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
 					return true;
 				}
 
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, ".ggp") == 2) {
+				if (ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
 					return true;
 				}
 			}
 
 			if (s1 != "") {
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(".wg ") + s1) == 2) {
+				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1) == 2) {
 					return true;
 				}
 			} else {
@@ -155,7 +146,7 @@ bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* 
 				s1 = monitor->OutPhrase;
 			}
 
-			cmd_line = ".ph ";
+			cmd_line = PHRASE_CMD + " ";
 
 			if (ph == "") {
 				cmd_line = cmd_line + s1 + " , " + s2; // standard substitution
@@ -168,37 +159,37 @@ bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* 
 				return true;
 			}
 
-			if (s2 != "" && ParseCommand(annabell, monitor, Display, clk0, clk1, string(".wg ") + s2) == 2) {
+			if (s2 != "" && ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s2) == 2) {
 				return true;
 			}
 
 			if (s1b != "") { // drop goal if there was a second cue
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, ".drop_goal") == 2) {
+				if (ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
 					return true;
 				}
 			}
 
 			// retrieve working phrase if necessary
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".ggp") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
 				return true;
 			}
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".drop_goal") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
 				return true;
 			}
 
-		} else if (cmd == ".ph" || cmd == ".wg") {
+		} else if (cmd == PHRASE_CMD || cmd == WORD_GROUP_CMD) {
 			return false;
 		}
 		else {
 
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".push_goal") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
 				return true;
 			}
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".ggp") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
 				return true;
 			}
 
-			cmd_line = ".wg";
+			cmd_line = WORD_GROUP_CMD;
 
 			for (unsigned int i = 1; i < input_token.size(); i++) {
 				buf = input_token[i];
@@ -209,23 +200,20 @@ bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* 
 				return true;
 			}
 
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, ".drop_goal") == 2) {
+			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
 				return true;
 			}
 		}
 
-		if (cmd == ".po") {
-			ParseCommand(annabell, monitor, Display, clk0, clk1, ".prw");
+		if (cmd == PARTIAL_REWARD_CMD) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, PARTIAL_REWARD_CMD2);
 		}
-		else if (cmd == ".o") {
-			ParseCommand(annabell, monitor, Display, clk0, clk1, ".rw");
+		else if (cmd == REWARD_CMD) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, REWARD_CMD2);
 		}
-		else if (cmd == ".pg") {
-			ParseCommand(annabell, monitor, Display, clk0, clk1, ".push_goal");
+		else if (cmd == PUSH_GOAL_CMD) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
 		}
 
 		return true;
-	}
-
-	return false;
 }

--- a/src/simplify.cc
+++ b/src/simplify.cc
@@ -34,19 +34,16 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 
 bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* clk0, timespec* clk1, vector<string> input_token) {
 
-	//I think this is not necessary, because is comparing the LITERAL ".ph*" string, not finding strings that start with ".ph"
-	string cmd = CommandUtils::removeTrailing(input_token[0], '*');
-
 	string cmd_line; //command_line
-
 	string buf; // buffer string
 
+	bool push_flag = false;
 
-		bool push_flag = false;
-
-		if (cmd == WORD_GROUP_CMD || cmd == REWARD_CMD || cmd == PARTIAL_REWARD_CMD) {
+		string cmd = CommandUtils::removeTrailing(input_token[0], '*');
+		if ((cmd == WORD_GROUP_CMD || cmd == REWARD_CMD || cmd == PARTIAL_REWARD_CMD) && CommandUtils::endsWith(input_token[0], '*')) {
 			push_flag = true;
 		}
+
 		buf = input_token[1];
 
 		if (input_token.size() == 2 && buf[0] == '/') {


### PR DESCRIPTION
Hi Bruno!
this pull request contains the following:

- Created EmptyCommand as the first Command subclass for a specific command. This one is a very simple one for when the input line is empty. So, this logic was moved from Command class to its own EmptyCommand subclass.
- Related to that, now the CommandFactory uses the input_line to decide which command it will instantiate.
- Created CommandConstants.h to centralize string constants for the commands and use them from simplify function and Command class.
- Added some more string handling methods to CommandUtils (and their corresponding unit tests in annabell-tests project as well).
- Added convenient method Display::printLn(), which is like print but adds the \n character at the end.
- Added comments to simplify.cc to try to explain its algorithm. Please tell me if I got this right because I'm not sure if I completely grasp it yet.

Regarding simplify, I will try to decouple it from the simple command processing, because as far as I understand, this functionality only deals with commands in their macro form, is that correct? That's why I've moved some "ifs" outside the call to simplify in order not to call it when its not a macro command (this is still in progress). I believe this should make easier to refactor each else-if in Command.cc into its new specific command subclass.

As always please let me know any comments,
best!
-Juan
