### PR TITLE
Implementation of regular expressions for telling macro commands from normal commands

### DIFF
--- a/src/CommandUtils.cc
+++ b/src/CommandUtils.cc
@@ -37,10 +37,23 @@ void CommandUtils::compileMacroRegex() {
 
 	//only compile the regex once, for performance reasons
 	if (CommandUtils::optimizedMacroRegex == NULL) {
-		compileRegex("(.*)(hello)+");
+		compileRegex("\\.(ph|pg|wg|po|o|wg\\*|po\\*|o\\*) \\/([^\\/]+)\\/([^\\/]*)\\/([^\\/]*)\\/($|( & ([^\\/]+)\\/([^\\/]*)\\/([^\\/]*)\\/)?$)");
 	}
 }
 
+/**
+ *  Macro commands take the following form:
+ *
+ *  .COMMAND /CUE/[PHRASE]/[WORD_GROUP]/[ & CUE2/[PHRASE2]/[WORD_GROUP2]]
+ *
+ *  Where:
+ *
+ *  - COMMAND is one of: ph, pg, wg, po, o, wg*, po*, o*
+ *  - CUE is a word group that must be extracted from the current working phrase and used as a cue
+ *  - PHRASE = is the phrase that must be retrieved from the long-term memory using cue.
+ *    This is optional. Is PHRASE is not supplied, the command takes the short form of /CUE//WORD_GROUP/ used for implementing substitutions like "you , I".
+ *  - WORD_GROUP optional group of words extracted from phrase
+ */
 bool CommandUtils::isMacroCommand(string inputString) {
 	compileMacroRegex();
 

--- a/src/CommandUtils.cc
+++ b/src/CommandUtils.cc
@@ -1,0 +1,145 @@
+#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#define PCRE_CODE_UNIT_WIDTH 8
+#include <pcre.h>
+#include "CommandUtils.h"
+
+using namespace std;
+
+pcre* CommandUtils::macroRegex;
+pcre_extra* CommandUtils::optimizedMacroRegex;
+
+void CommandUtils::compileRegex(const char* regexString) {
+
+	const char* pcreErrorStr;
+	int pcreErrorOffset;
+
+	CommandUtils::macroRegex = pcre_compile(regexString, 0, &pcreErrorStr, &pcreErrorOffset, NULL);
+	if (CommandUtils::macroRegex == NULL) {
+		printf("ERROR: Could not compile '%s': %s\n", regexString, pcreErrorStr);
+		//TODO: replace with exception thrown
+		exit(1);
+	}
+	// Optimize the regex
+	CommandUtils::optimizedMacroRegex = pcre_study(CommandUtils::macroRegex, 0, &pcreErrorStr);
+	if (pcreErrorStr != NULL) {
+		printf("ERROR: Could not study '%s': %s\n", regexString, pcreErrorStr);
+		//TODO: replace with exception thrown
+		exit(1);
+	}
+}
+
+void CommandUtils::compileMacroRegex() {
+
+	//only compile the regex once, for performance reasons
+	if (CommandUtils::optimizedMacroRegex == NULL) {
+		compileRegex("(.*)(hello)+");
+	}
+}
+
+bool CommandUtils::isMacroCommand(string inputString) {
+	compileMacroRegex();
+
+	/** the result of trying to match the regex with the inputString */
+	int matchesCount;
+
+	/** magic number of maximum possible matches to store. PCRE interface needs this upfront :( ... */
+	const int MATCH_INDEXES_ARRAY_SIZE = 30;
+
+	/** an array to store the indexes of the possible matches of the regex in the inputString */
+	int subStrVec[MATCH_INDEXES_ARRAY_SIZE];
+
+	matchesCount = pcre_exec(CommandUtils::macroRegex, CommandUtils::optimizedMacroRegex, inputString.c_str(),
+			inputString.length(), 0, 0, subStrVec, MATCH_INDEXES_ARRAY_SIZE);
+
+	if (matchesCount == PCRE_ERROR_NOMATCH) {
+		// regex did not match. command is not a macro.
+		return false;
+
+	} else if (matchesCount >= 0) {
+		// there are matches with the regex. command is a macro.
+		return true;
+
+	} else {
+		// some error occured
+		printf("Error in regex %i\n", matchesCount);
+
+		//TODO: replace with exception thrown
+		exit(matchesCount);
+	}
+}
+
+/**
+ * This function takes care of plural suffix.
+ * ie. replaces plural occurences with "-s"
+ * @param input a string
+ * @return "-s" if the input represents a plural, and the unchanged input otherwise.
+ */
+string CommandUtils::processPlural(string input) {
+	if (input == "-es") {
+		return "-s";
+	} else {
+		return input;
+	}
+}
+
+/**
+ * This function takes care of the articles, simplifying "an" occurrences to "a".
+ * @param input a string
+ * @return "a" if the input is "an", and the unchanged input otherwise.
+ */
+string CommandUtils::processArticle(string input) {
+	if (input == "an") {
+		return "a";
+	} else {
+		return input;
+	}
+}
+
+/**
+ * @returns true if input string starts with provided character, false otherwise.
+ */
+bool CommandUtils::startsWith(string input, char character) {
+	return input[0] == character;
+}
+
+/**
+ * @returns true if input string starts with provided substring, false otherwise.
+ */
+bool CommandUtils::startsWith(string input, string subString) {
+	if (input.find(subString) == 0) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/**
+ * @returns true if input string ends with provided character, false otherwise.
+ */
+bool CommandUtils::endsWith(string input, char character) {
+	int lastIndex = input.size() - 1;
+	return input[lastIndex] == character;
+}
+
+/**
+ * @returns the input string, minus its last character
+ */
+string CommandUtils::removeTrailing(string input) {
+	return input.substr(0, input.size() - 1);
+}
+
+/**
+ * @returns the input string, minus its last character, is such last character is equal to the character specified as second argument, or the unchanged specified string otherwise
+ */
+string CommandUtils::removeTrailing(string input, char character) {
+	if (CommandUtils::endsWith(input, character)) {
+		return input.substr(0, input.size() - 1);
+	} else {
+		return input;
+	}
+}

--- a/src/CommandUtils.cc
+++ b/src/CommandUtils.cc
@@ -37,6 +37,7 @@ void CommandUtils::compileMacroRegex() {
 
 	//only compile the regex once, for performance reasons
 	if (CommandUtils::optimizedMacroRegex == NULL) {
+		//TODO: use CommandConstants constants and split the regex into a more human-readable concatenation of such constants.
 		compileRegex("\\.(ph|pg|wg|po|o|wg\\*|po\\*|o\\*) \\/([^\\/]+)\\/([^\\/]*)\\/([^\\/]*)\\/($|( & ([^\\/]+)\\/([^\\/]*)\\/([^\\/]*)\\/)?$)");
 	}
 }

--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -1,83 +1,75 @@
 #ifndef SRC_COMMANDUTILS_H_
 #define SRC_COMMANDUTILS_H_
 
+#include <string.h>
+#include <cstdio>
+#include <cstdlib>
 #include <string>
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#define PCRE_CODE_UNIT_WIDTH 8
+#include <pcre.h>
+
 
 using namespace std;
 
 class CommandUtils {
+private:
+	static pcre* macroRegex;
+	static pcre_extra* optimizedMacroRegex;
+
+	static void compileMacroRegex();
+
 public:
+
+	/**
+	 * This is public for testing purporses only.
+	 */
+	static void compileRegex(const char* regexString);
+
+	static bool isMacroCommand(string input);
+
 	/**
 	 * This function takes care of plural suffix.
 	 * ie. replaces plural occurences with "-s"
 	 * @param input a string
 	 * @return "-s" if the input represents a plural, and the unchanged input otherwise.
 	 */
-	static string processPlural(string input) {
-		if (input == "-es") {
-			return "-s";
-		} else {
-			return input;
-		}
-	}
+	static string processPlural(string input);
 
 	/**
 	 * This function takes care of the articles, simplifying "an" occurrences to "a".
 	 * @param input a string
 	 * @return "a" if the input is "an", and the unchanged input otherwise.
 	 */
-	static string processArticle(string input) {
-		if (input == "an") {
-			return "a";
-		} else {
-			return input;
-		}
-	}
+	static string processArticle(string input);
 
 	/**
 	 * @returns true if input string starts with provided character, false otherwise.
 	 */
-	static bool startsWith(string input, char character) {
-		return input[0] == character;
-	}
+	static bool startsWith(string input, char character);
 
 	/**
 	 * @returns true if input string starts with provided substring, false otherwise.
 	 */
-	static bool startsWith(string input, string subString) {
-		if (input.find(subString) == 0) {
-			return true;
-		} else {
-			return false;
-		}
-	}
+	static bool startsWith(string input, string subString);
 
 	/**
 	 * @returns true if input string ends with provided character, false otherwise.
 	 */
-	static bool endsWith(string input, char character) {
-		int lastIndex = input.size() - 1;
-		return input[lastIndex] == character;
-	}
+	static bool endsWith(string input, char character);
 
 	/**
 	 * @returns the input string, minus its last character
 	 */
-	static string removeTrailing(string input) {
-		return input.substr(0, input.size() - 1);
-	}
+	static string removeTrailing(string input);
 
 	/**
 	 * @returns the input string, minus its last character, is such last character is equal to the character specified as second argument, or the unchanged specified string otherwise
 	 */
-	static string removeTrailing(string input, char character) {
-		if (CommandUtils::endsWith(input, character)) {
-			return input.substr(0, input.size() - 1);
-		} else {
-			return input;
-		}
-	}
+	static string removeTrailing(string input, char character);
 
 };
 
 #endif /* SRC_COMMANDUTILS_H_ */
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,11 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h AnnabellFlags.h Command.h EmptyCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellFlags.h Command.h EmptyCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc Command.cc EmptyCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc 
+annabell_SOURCES = AnnabellFlags.cc CommandUtils.cc Command.cc EmptyCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc 
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
-annabell_LDFLAGS = @OPENMP_CXXFLAGS@
+annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre
 

--- a/src/ParseCommandTests.cc
+++ b/src/ParseCommandTests.cc
@@ -1,0 +1,58 @@
+#include "ParseCommandTests.h"
+
+#include <CommandUtils.h>
+#include <gtest/gtest.h>
+#include <string.h>
+
+TEST(CommandUtilsStringTests, pluralTest) {
+	EXPECT_EQ("-s", CommandUtils::processPlural("-es"));
+	EXPECT_EQ("-s", CommandUtils::processPlural("-s"));
+	EXPECT_EQ("shouldNotChange", CommandUtils::processPlural("shouldNotChange"));
+}
+
+TEST(CommandUtilsStringTests, articleTest) {
+	EXPECT_EQ("a", CommandUtils::processArticle("an"));
+	EXPECT_EQ("a", CommandUtils::processArticle("a"));
+	EXPECT_EQ("shouldNotChange", CommandUtils::processArticle("shouldNotChange"));
+}
+
+TEST(CommandUtilsStringTests, startsWithCharTest) {
+	EXPECT_TRUE(CommandUtils::startsWith("abcdef", 'a'));
+	EXPECT_FALSE(CommandUtils::startsWith("abcdef", 'f'));
+}
+
+TEST(CommandUtilsStringTests, startsWithStringTest) {
+	EXPECT_TRUE(CommandUtils::startsWith("abcdef", "abc"));
+	EXPECT_TRUE(CommandUtils::startsWith("abcdef", "abcdef"));
+	EXPECT_FALSE(CommandUtils::startsWith("abcdef", "bcd"));
+}
+
+TEST(CommandUtilsStringTests, endsWithTest) {
+	EXPECT_TRUE(CommandUtils::endsWith("abcdef", 'f'));
+	EXPECT_FALSE(CommandUtils::endsWith("abcdef", 'a'));
+}
+
+TEST(CommandUtilsStringTests, removeTrailingTest) {
+	EXPECT_EQ("abcde", CommandUtils::removeTrailing("abcdef"));
+	EXPECT_EQ("abcdef", CommandUtils::removeTrailing("abcdef", 'x'));
+	EXPECT_EQ("abcdef", CommandUtils::removeTrailing("abcdef*", '*'));
+}
+
+TEST(CommandUtilsMacroTests, regexTests) {
+	CommandUtils::compileRegex("hello");
+	EXPECT_TRUE(CommandUtils::isMacroCommand("hello"));
+	EXPECT_TRUE(CommandUtils::isMacroCommand("This should hello match"));
+	EXPECT_FALSE(CommandUtils::isMacroCommand("goodbye"));
+
+	CommandUtils::compileRegex("(.*)(hello)+");
+	EXPECT_TRUE(CommandUtils::isMacroCommand("This should match hello"));
+	EXPECT_TRUE(CommandUtils::isMacroCommand("This should match hello! because it hello should"));
+	EXPECT_FALSE(CommandUtils::isMacroCommand("This should not match"));
+
+
+}
+
+int runAllTests(int argc, char** argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/src/ParseCommandTests.cc
+++ b/src/ParseCommandTests.cc
@@ -38,18 +38,37 @@ TEST(CommandUtilsStringTests, removeTrailingTest) {
 	EXPECT_EQ("abcdef", CommandUtils::removeTrailing("abcdef*", '*'));
 }
 
-TEST(CommandUtilsMacroTests, regexTests) {
-	CommandUtils::compileRegex("hello");
-	EXPECT_TRUE(CommandUtils::isMacroCommand("hello"));
-	EXPECT_TRUE(CommandUtils::isMacroCommand("This should hello match"));
-	EXPECT_FALSE(CommandUtils::isMacroCommand("goodbye"));
+TEST(CommandUtilsMacroTests, macroDetectionTests) {
 
-	CommandUtils::compileRegex("(.*)(hello)+");
-	EXPECT_TRUE(CommandUtils::isMacroCommand("This should match hello"));
-	EXPECT_TRUE(CommandUtils::isMacroCommand("This should match hello! because it hello should"));
-	EXPECT_FALSE(CommandUtils::isMacroCommand("This should not match"));
+	//valid macro form
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".ph /mammal/the dog is a mammal/dog/"));
 
+	//valid macro form with two expressions separated by an '&' character
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".ph /mammal/the dog is a mammal/dog/ & mammal/the dog is a mammal/dog/"));
 
+	//should fail because .ph* is not a valid macro command
+	EXPECT_FALSE(CommandUtils::isMacroCommand(".ph* /mammal/the dog is a mammal/dog/"));
+
+	//valid commands ending with asterisk
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".wg* /mammal/the dog is a mammal/dog/"));
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".po* /mammal/the dog is a mammal/dog/"));
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".o* /mammal/the dog is a mammal/dog/"));
+
+	//.wg is nos a valid macro command
+	EXPECT_FALSE(CommandUtils::isMacroCommand(".wg the dog is a mammal"));
+
+	//valid forms, omitting optional PHRASE to use as substitution
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".po* /mammal//dog/"));
+	EXPECT_TRUE(CommandUtils::isMacroCommand(".ph /mammal//dog/ & mammal//dog/"));
+
+	//.f command is similar because it has '/' characters, but is nos a macro
+	EXPECT_FALSE(CommandUtils::isMacroCommand(".f /path/to/a/file.txt"));
+
+	//just a phrase, not a command
+	EXPECT_FALSE(CommandUtils::isMacroCommand("the dog is a mammal"));
+
+	//should fail because it lacks the ending '/'
+	EXPECT_FALSE(CommandUtils::isMacroCommand(".ph /mammal/the dog is a mammal/dog"));
 }
 
 int runAllTests(int argc, char** argv) {

--- a/src/ParseCommandTests.h
+++ b/src/ParseCommandTests.h
@@ -1,0 +1,8 @@
+#ifndef PARSECOMMANDTESTS_H_
+#define PARSECOMMANDTESTS_H_
+
+#include "CommandUtils.h"
+
+int runAllTests(int argc, char** argv);
+
+#endif /* PARSECOMMANDTESTS_H_ */

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -1,19 +1,19 @@
 /*
-Copyright (C) 2015 Bruno Golosio
+ Copyright (C) 2015 Bruno Golosio
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <Annabell.h>
 #include <Monitor.h>
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "AnnabellFlags.h"
 #include "CommandFactory.h"
 #include "Command.h"
+#include "ParseCommandTests.h"
 
 using namespace std;
 using namespace sizes;
@@ -42,14 +43,32 @@ int LastGB;
 int StoredStActI;
 
 int Interface(Annabell *annabell, Monitor *Mon);
+int annabellMain();
 
-int main() {
+int main(int argc, char** argv) {
+
+	bool isTestMode = false;
+
+	for (int i = 0; i < argc; i++) {
+		if (argv[i] == string("test")) {
+			isTestMode = true;
+			break;
+		}
+	}
+
+	if (isTestMode) {
+		return runAllTests(argc, argv);
+	} else {
+		return annabellMain();
+	}
+}
+
+int annabellMain() {
 	try {
 		init_randmt(12345);
 
 		Annabell *annabell = new Annabell();
 		Monitor *Mon = new Monitor(annabell);
-
 
 		Interface(annabell, Mon);
 
@@ -64,6 +83,7 @@ int main() {
 		cerr << "Unrecognized error.\n";
 		return 1;
 	}
+
 }
 
 int Interface(Annabell *annabell, Monitor *mon) {


### PR DESCRIPTION
Hi Bruno!
This pull request contains the following changes:

- Added PCRE (http://www.pcre.org/) library for regular expressions. I went for the native C++11 `<regex>` option first, but the current code seems to be C++03 compliant so I couldn't without getting into new compilation errors.

- With the above mentioned regular expressions support, I've implemented `CommandUtils::isMacroCommand(string)`, which tells if a command is in macro form or not, and added the corresponding unit tests to `ParseCommandTests.cc`. Later this same regex can be used to parse the recognized command using capture groups, simplifying the parsing process a lot. Please let me know if I got the regex right.

- Moved the tests from annabell-tests projects into annabell. I wanted to keep them separated but the building process started to complicate too much I think. I'm not very familiar with Autotools, so I couldn't figure out how to put the tests in a separated `/test` source folder, which would be more correct. For now they are in `/src`.

- Now `annabell_main::main` function supports two ways of executing. Without any arguments, it runs as always. But if the argument "`test`" is specified when run, it runs in "test mode", executing the unit tests.

Unfortunately, this changes add the dependency for libraries `gtest`, `pthread` (unit tests) and `pcre` (regex) to the linking process of annabell. I wanted to avoid that but I didn't know how. However, the installation of this libraries is covered in their respective websites https://github.com/google/googletest and http://pcre.org/ and it should be straightforward since they are very commonly used libraries. (the unit tests ones you already got them running).

Any comments or ideas just let me know, 
thanks!
-Juan