### PR TITLE
Fix for #22 - segfault in files with empty lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ A cognitive neural architecture able to learn and communicate through natural la
 
 Installation and usage
 ----------------------
-Installation and usage instruction are provided in the document:
 
-* annabell-x.x.x_man.pdf
+In order to build the project the following libraries are needed:
 
-where x.x.x refers to the version number.
+ - **pthread** and **gtest**: [Download from GoogleTest project](https://github.com/google/googletest)
+ - **pcre**: [Download from pcre.org](http://pcre.org/)
+
+Additionally, installation and usage instructions are provided in the document **annabell-x.x.x_man.pdf**, where x.x.x refers to the version number.
+

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <vector>
 #include "CommandConstants.h"
+#include "CommandFactory.h"
 
 using namespace sizes;
 
@@ -574,22 +575,30 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   ////////////////////////////////////////
   // Loads phrases and/or commands from the file file_name.
   ////////////////////////////////////////
-  else if (buf == FILE_CMD_LONG || buf == FILE_CMD) { // read phrases/commands from file
-    if (input_token.size()<2) {
-      Display->Warning("a file name should be provided as argument.");
-      return 1;
-    }
-    ifstream fs(input_token[1].c_str());
-    if (!fs) {
-      Display->Warning("Input file not found.");
-      return 1;
-    }
-    while(getline (fs, buf))  {
-      //Display->Print(buf+"\n");
-      if (ParseCommand(annabell, Mon, Display, clk0, clk1, buf)==2) break;
-    }
-    return 0;
-  }
+	else if (buf == FILE_CMD_LONG || buf == FILE_CMD) { // read phrases/commands from file
+
+		if (input_token.size() < 2) {
+			Display->Warning("a file name should be provided as argument.");
+			return 1;
+		}
+
+		ifstream fs(input_token[1].c_str());
+		if (!fs) {
+			Display->Warning("Input file not found.");
+			return 1;
+		}
+
+		while (getline(fs, buf)) {
+
+			//Display->Print(buf+"\n");
+			Command* c = CommandFactory::newCommand(buf);
+			int	commandResult = c->execute();
+			if(commandResult == 2) {
+				break;
+			}
+		}
+		return 0;
+	}
 
   ////////////////////////////////////////
   // Gets the input phrase provided as argument without building the


### PR DESCRIPTION
Now instead of calling ParseCommand directly, the file command uses de CommandFactory to proces each line, analog to what the Interface does with the stream from the command line.

This is temporary, asi the file command should be moved to a separated command itself and then perhaps this could change.

The empty line is interpreted as an .end_context, which is the same as it was before the EmptyCommand implementation as far as I can tell. The same happened if just ENTER is pressed in the command line.