### PR TITLE
Fix in main arguments processing, otherwise test mode would not run. Created subclasses for FileCommand, CommentCommand and QuitCommand.

### DIFF
--- a/simple_examples/example1.txt
+++ b/simple_examples/example1.txt
@@ -1,3 +1,4 @@
+#Example 1
 the turtle is a reptile
 the eagle is a bird
 the dog is a mammal

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -112,13 +112,6 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 		input_token.push_back(buf);
 		buf = "";
 	}
-	if (buf != "") {
-		int l = buf.size() - 1;
-		if (buf[l] == ' ') {
-			buf.erase(l);
-		}
-		input_token.push_back(buf);
-	}
 
 	if (input_token.size() >= 2
 			&& (CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD)
@@ -608,36 +601,6 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 
     return 0;
   }
-
-  ////////////////////////////////////////
-  // Loads phrases and/or commands from the file file_name.
-  ////////////////////////////////////////
-	else if (buf == FILE_CMD_LONG || buf == FILE_CMD) { // read phrases/commands from file
-
-		if (input_token.size() < 2) {
-			Display->Warning("a file name should be provided as argument.");
-			return 1;
-		}
-
-		ifstream fs(input_token[1].c_str());
-		if (!fs) {
-			Display->Warning("Input file not found.");
-			return 1;
-		}
-
-		while (getline(fs, buf)) {
-
-			//Display->Print(buf+"\n");
-			Command* c = CommandFactory::newCommand(buf);
-			int	commandResult = c->execute();
-			delete c;
-			if(commandResult == 2) {
-				break;
-			}
-		}
-		return 0;
-	}
-
   ////////////////////////////////////////
   // Gets the input phrase provided as argument without building the
   // associations between the word groups and the phrase.

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -152,11 +152,7 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
   }
   Display->Print(input_line+"\n");
   ////////////////////////////////////////
-  // Exits the program or the current input file
-  ////////////////////////////////////////
-  if (buf == QUIT_CMD_LONG || buf == QUIT_CMD) return 2; // quit
-  ////////////////////////////////////////
-  else if (buf == CONTINUE_CONTEXT_CMD_LONG || buf == CONTINUE_CONTEXT_CMD) { // continue context
+  if (buf == CONTINUE_CONTEXT_CMD_LONG || buf == CONTINUE_CONTEXT_CMD) { // continue context
     if (input_token.size()>2) {
       Display->Warning("syntax error.");
       return 1;

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -65,8 +65,10 @@ string to_string(T const& value) {
     return sstr.str();
 }
 
+Command::Command() {
+}
 
-Command::Command(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clock0, timespec* clock1, string input_line) {
+void Command::init(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clock0, timespec* clock1, string input_line) {
 	this->annabell = annabell;
 	this->Mon = monitor;
 	this->Display = aDisplay;
@@ -135,11 +137,6 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 
   string target_phrase;
   buf = input_token[0];
-  ////////////////////////////////////////
-  if (buf[0] == COMMENT_CMD) { // input line is a comment
-    Display->Print(input_line+"\n");
-    return 0;
-  }
   ////////////////////////////////////////
   if (buf[0]!='.' || (buf[1]=='.' && buf[2]=='.')) {
     // if token does not start with "." or if token is "..."

--- a/src/Command.h
+++ b/src/Command.h
@@ -25,7 +25,8 @@ protected:
 	string input_line;
 
 public:
-	Command(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clk0, timespec* clk1, string input_line);
+	Command();
+	void init(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clk0, timespec* clk1, string input_line);
 	virtual int execute();
 	virtual ~Command();
 };

--- a/src/CommandFactory.cc
+++ b/src/CommandFactory.cc
@@ -10,7 +10,7 @@
 #include <CommandUtils.h>
 #include <CommentCommand.h>
 #include <EmptyCommand.h>
-#include <string>
+#include <FileCommand.h>
 
 struct timespec;
 
@@ -36,6 +36,9 @@ Command* CommandFactory::newCommand(string input) {
 
 	} else if (CommandUtils::startsWith(input, COMMENT_CMD)) {
 		newCommand = new CommentCommand();
+
+	} else if (CommandUtils::startsWith(input, FILE_CMD) || CommandUtils::startsWith(input, FILE_CMD_LONG)) {
+		newCommand = new FileCommand();
 
 	} else {
 		newCommand = new Command();

--- a/src/CommandFactory.cc
+++ b/src/CommandFactory.cc
@@ -11,6 +11,7 @@
 #include <CommentCommand.h>
 #include <EmptyCommand.h>
 #include <FileCommand.h>
+#include <QuitCommand.h>
 
 struct timespec;
 
@@ -40,12 +41,15 @@ Command* CommandFactory::newCommand(string input) {
 	} else if (CommandUtils::startsWith(input, FILE_CMD) || CommandUtils::startsWith(input, FILE_CMD_LONG)) {
 		newCommand = new FileCommand();
 
+	} else if (CommandUtils::startsWith(input, QUIT_CMD) || CommandUtils::startsWith(input, QUIT_CMD_LONG)) {
+		newCommand = new QuitCommand();
+
 	} else {
 		newCommand = new Command();
 	}
 
-	newCommand->init(CommandFactory::annabell, CommandFactory::monitor, CommandFactory::aDisplay,
-			CommandFactory::clk0, CommandFactory::clk1, input);
+	newCommand->init(CommandFactory::annabell, CommandFactory::monitor, CommandFactory::aDisplay, CommandFactory::clk0,
+			CommandFactory::clk1, input);
 
 	return newCommand;
 }

--- a/src/CommandFactory.cc
+++ b/src/CommandFactory.cc
@@ -5,7 +5,10 @@
  *      Author: jpp
  */
 
+#include <CommandConstants.h>
 #include <CommandFactory.h>
+#include <CommandUtils.h>
+#include <CommentCommand.h>
 #include <EmptyCommand.h>
 #include <string>
 
@@ -25,16 +28,21 @@ void CommandFactory::init(Annabell* annabell, Monitor* monitor, display* aDispla
 	CommandFactory::clk1 = clk1;
 }
 
-void CommandFactory::pepe() {};
-
 Command* CommandFactory::newCommand(string input) {
+	Command* newCommand;
+
 	if (input.empty()) {
-		//aDisplay->Println("Creating EmptyCommand");
-		return new EmptyCommand(CommandFactory::annabell, CommandFactory::monitor, CommandFactory::aDisplay,
-				CommandFactory::clk0, CommandFactory::clk1, input);
+		newCommand = new EmptyCommand();
+
+	} else if (CommandUtils::startsWith(input, COMMENT_CMD)) {
+		newCommand = new CommentCommand();
+
 	} else {
-		//aDisplay->Println("Creating base Command");
-		return new Command(CommandFactory::annabell, CommandFactory::monitor, CommandFactory::aDisplay,
-				CommandFactory::clk0, CommandFactory::clk1, input);
+		newCommand = new Command();
 	}
+
+	newCommand->init(CommandFactory::annabell, CommandFactory::monitor, CommandFactory::aDisplay,
+			CommandFactory::clk0, CommandFactory::clk1, input);
+
+	return newCommand;
 }

--- a/src/CommandFactory.h
+++ b/src/CommandFactory.h
@@ -40,8 +40,6 @@ public:
 	 * @return an instance of the sub-type of Command corresponding to the issued string line command.
 	 */
 	static Command* newCommand(string input);
-
-	static void pepe();
 };
 
 #endif /* SRC_COMMANDFACTORY_H_ */

--- a/src/CommentCommand.cc
+++ b/src/CommentCommand.cc
@@ -1,0 +1,17 @@
+/*
+ * CommentCommand.cc
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#include "CommentCommand.h"
+
+CommentCommand::CommentCommand() :
+		Command() {
+}
+
+int CommentCommand::execute() {
+	this->Display->Print(this->input_line + "\n");
+	return 0;
+}

--- a/src/CommentCommand.h
+++ b/src/CommentCommand.h
@@ -1,0 +1,22 @@
+/*
+ * CommentCommand.h
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#ifndef SRC_COMMENTCOMMAND_H_
+#define SRC_COMMENTCOMMAND_H_
+
+#include "Command.h"
+
+/**
+ * Class CommentCommand represents the action corresponding to when the user enters a comment line as command.
+ */
+class CommentCommand: public Command {
+public:
+	CommentCommand();
+	int execute();
+};
+
+#endif /* SRC_COMMENTCOMMAND_H_ */

--- a/src/EmptyCommand.cc
+++ b/src/EmptyCommand.cc
@@ -23,11 +23,9 @@ int GetInputPhrase(Annabell *annabell, Monitor *Mon, string input_phrase);
 int ExecuteAct(Annabell *annabell, Monitor *Mon, int rwd_act, int acq_act, int el_act);
 string Exploitation(Annabell *annabell, Monitor *Mon, display* Display, int n_iter);
 
-EmptyCommand::EmptyCommand(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clk0, timespec* clk1,
-		string input_line) :
-		Command(annabell, monitor, aDisplay, clk0, clk1, input_line) {
+EmptyCommand::EmptyCommand() :
+		Command() {
 }
-;
 
 int EmptyCommand::execute() {
 	string target_phrase;

--- a/src/EmptyCommand.h
+++ b/src/EmptyCommand.h
@@ -15,8 +15,7 @@
  */
 class EmptyCommand: public Command {
 public:
-	EmptyCommand(Annabell* annabell, Monitor* monitor, display* aDisplay, timespec* clk0, timespec* clk1,
-			string input_line);
+	EmptyCommand();
 	int execute();
 };
 

--- a/src/FileCommand.cc
+++ b/src/FileCommand.cc
@@ -1,0 +1,56 @@
+/*
+ * FileCommand.cc
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#include <CommandFactory.h>
+#include <display.h>
+#include <FileCommand.h>
+#include <iosfwd>
+#include <iostream>
+#include <string>
+#include <vector>
+
+FileCommand::FileCommand() {
+	Command();
+}
+
+int FileCommand::execute() {
+
+	vector<string> input_token;
+
+	stringstream ss(input_line); // Insert the line into a stream
+	string buf1; // buffer strings
+
+	while (ss >> buf1) {
+		// split line into space-separated tokens
+		input_token.push_back(buf1);
+	}
+
+	if (input_token.size() < 2) {
+		Display->Warning("a file name should be provided as argument.");
+		return 1;
+	}
+
+	ifstream fs(input_token[1].c_str());
+	if (!fs) {
+		Display->Warning("Input file not found.");
+		return 1;
+	}
+
+	string fileLineBuffer;
+	while (getline(fs, fileLineBuffer)) {
+		Command* c = CommandFactory::newCommand(fileLineBuffer);
+		int commandResult = c->execute();
+		delete c;
+
+		if (commandResult == 2) {
+			break;
+		}
+	}
+
+	return 0;
+}
+

--- a/src/FileCommand.h
+++ b/src/FileCommand.h
@@ -1,0 +1,22 @@
+/*
+ * FileCommand.h
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#ifndef SRC_FILECOMMAND_H_
+#define SRC_FILECOMMAND_H_
+
+#include "Command.h"
+
+/**
+ * Class CommentCommand represents the action corresponding to when the user enters a file command.
+ */
+class FileCommand: public Command {
+public:
+	FileCommand();
+	int execute();
+};
+
+#endif /* SRC_FILECOMMAND_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h FileCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h FileCommand.h QuitCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc FileCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
+annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc FileCommand.cc QuitCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
+annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h FileCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
+annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc FileCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre

--- a/src/QuitCommand.cc
+++ b/src/QuitCommand.cc
@@ -1,0 +1,16 @@
+/*
+ * QuitCommand.cc
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#include "QuitCommand.h"
+
+QuitCommand::QuitCommand() {
+	Command();
+}
+
+int QuitCommand::execute() {
+	return 2;
+}

--- a/src/QuitCommand.h
+++ b/src/QuitCommand.h
@@ -1,0 +1,19 @@
+/*
+ * QuitCommand.h
+ *
+ *  Created on: Feb 21, 2016
+ *      Author: jpp
+ */
+
+#ifndef SRC_QUITCOMMAND_H_
+#define SRC_QUITCOMMAND_H_
+
+#include "Command.h"
+
+class QuitCommand: public Command {
+public:
+	QuitCommand();
+	int execute();
+};
+
+#endif /* SRC_QUITCOMMAND_H_ */

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -121,6 +121,7 @@ int Interface(Annabell *annabell, Monitor *mon) {
 		if (lineRead) {
 			Command* c = CommandFactory::newCommand(input_line);
 			commandResult = c->execute();
+			delete c;
 		}
 	}
 

--- a/src/annabell_main.cc
+++ b/src/annabell_main.cc
@@ -146,6 +146,7 @@ int ReadArg(int argc, char** argv, bool &isTestMode, string &param_file)
     }
     else if (str=="test") {
       isTestMode = true;
+      break;
     }
     else {
       cerr << "Wrong input arguments. Usage : " << argv[0] << " [arguments]\n";


### PR DESCRIPTION
Hi Bruno,
I've added this small change in the processing of main arguments, because otherwise, if you specify only "test", the while loop would continue and it would result in a "wrong input arguments" error, and the tests cannot be run.

I've also continued with the refactor of the Commands hierarchy, creating subclasses of Command for the FileCommand, QuitCommand and CommentCommand. This are of course rather trivial commands, but sill, we continue to cleanup and separate the "system" commands if you will, from the more "core" commands (reward, push goal, etc). 

I think that the code you added for fix #10 is not needed anymore, because now FileCommand has its own, more simple, tokenization of the input string (does not need to account for plural replacements, macro forms, etc), so I've removed it also.

best,
-Juan