### PR TITLE
Added checks to avoid calling simplify when it's not necessary. Added…

### DIFF
--- a/src/Command.cc
+++ b/src/Command.cc
@@ -86,6 +86,40 @@ int Command::execute() {
 }
 
 /**
+ * @returns true is specified command supports macro form
+ * (doesn't mean the input line is actually a macro, just that there is a possibility that it is one.
+ */
+bool isPossibleMacroCommand(const vector<string>& input_token) {
+	return CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD)
+			|| CommandUtils::startsWith(input_token[0], REWARD_CMD)
+			|| CommandUtils::startsWith(input_token[0], PARTIAL_REWARD_CMD)
+			|| CommandUtils::startsWith(input_token[0], PUSH_GOAL_CMD)
+			|| CommandUtils::startsWith(input_token[0], PHRASE_CMD);
+}
+
+/**
+ * @returns true if this input is possibly a macro command
+ */
+bool isPossibleMacro(const vector<string>& input_token) {
+	return input_token.size() >= 2 && isPossibleMacroCommand(input_token);
+}
+
+/**
+ * @returns true is this input is a simple macro command (ie. it is a macro composed by two tokens)
+ */
+bool isSimpleMacroCommand(const vector<string>& input_token) {
+	return input_token.size() == 2 && CommandUtils::startsWith(input_token[1], '/');
+}
+
+/**
+ * @returns true is this input does not correspond to neither a PHRASE command, nor to a WORD_GROUP command.
+ */
+bool isNotPhraseOrWordGroup(const vector<string>& input_token) {
+	return !CommandUtils::startsWith(input_token[0], PHRASE_CMD)
+			&& !CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD);
+}
+
+/**
  * Read command or input phrase from command line.
  * @returns 2 for .quit command.
  */
@@ -113,19 +147,10 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 		buf = "";
 	}
 
-	if (input_token.size() >= 2
-			&& (CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD)
-					|| CommandUtils::startsWith(input_token[0], REWARD_CMD)
-					|| CommandUtils::startsWith(input_token[0], PARTIAL_REWARD_CMD)
-					|| CommandUtils::startsWith(input_token[0], PUSH_GOAL_CMD)
-					|| CommandUtils::startsWith(input_token[0], PHRASE_CMD))) {
+	if (isPossibleMacro(input_token) && (isSimpleMacroCommand(input_token) || isNotPhraseOrWordGroup(input_token))) {
 
-		bool endProcessing;
-		endProcessing = simplify(annabell, Mon, Display, clk0, clk1, input_token);
-
-		if (endProcessing) {
-			return 0;
-		}
+		simplify(annabell, Mon, Display, clk0, clk1, input_token);
+		return 0;
 	}
 
   string target_phrase;

--- a/src/simplify.cc
+++ b/src/simplify.cc
@@ -32,211 +32,173 @@ using namespace std;
 
 int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* clk0, timespec* clk1, string input_line);
 
-bool simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* clk0, timespec* clk1, vector<string> input_token) {
+void simplify(Annabell *annabell, Monitor *monitor, display* Display, timespec* clk0, timespec* clk1,
+		vector<string> input_token) {
 
 	string cmd_line; //command_line
 	string buf; // buffer string
 
 	bool push_flag = false;
 
-		string cmd = CommandUtils::removeTrailing(input_token[0], '*');
-		if ((cmd == WORD_GROUP_CMD || cmd == REWARD_CMD || cmd == PARTIAL_REWARD_CMD) && CommandUtils::endsWith(input_token[0], '*')) {
-			push_flag = true;
+	string cmd = CommandUtils::removeTrailing(input_token[0], '*');
+	if ((cmd == WORD_GROUP_CMD || cmd == REWARD_CMD || cmd == PARTIAL_REWARD_CMD)
+			&& CommandUtils::endsWith(input_token[0], '*')) {
+		push_flag = true;
+	}
+
+	buf = input_token[1];
+
+	if (input_token.size() == 2 && CommandUtils::startsWith(input_token[1], '/')) {
+
+		//Entered command is a macro, because it has only two tokens, and the second token starts with the character '/'.
+		//For example: .o /mammal/the dog is a mammal/dog/
+
+		unsigned int i = 0;
+
+		string s1 = "";
+		string s1b = "";
+		string s2 = "";
+		string ph = "";
+
+		for (i = 1; i < buf.size(); i++) {
+			if (buf[i] == '/' || buf[i] == '&') {
+				break;
+			}
+
+			s1 = s1 + buf[i];
 		}
 
-		buf = input_token[1];
+		if (i >= buf.size()) {
+			Display->Warning("Syntax error 1 on simplifying");
+			return;
+		}
 
-		if (input_token.size() == 2 && CommandUtils::startsWith(input_token[1], '/')) {
-
-			//Entered command is a macro, because it has only two tokens, and the second token starts with the character '/'.
-			//For example: .o /mammal/the dog is a mammal/dog/
-
-			unsigned int i;
-			string s1, s1b, s2, ph;
-			i = 0;
-			s1 = s1b = s2 = ph = "";
-
-			for (i = 1; i < buf.size(); i++) {
-				if (buf[i] == '/' || buf[i] == '&') {
-					break;
-				}
-
-				s1 = s1 + buf[i];
-			}
-
-			if (i >= buf.size()) {
-				Display->Warning("Syntax error 1 on simplifying");
-				return true;
-			}
-
-			if (buf[i] == '&') {
-				for (i++; i < buf.size(); i++) {
-					if (buf[i] == '/') {
-						break;
-					}
-
-					s1b = s1b + buf[i];
-				}
-				if (i == buf.size()) {
-					Display->Warning("Syntax error 2 on simplifying");
-					return true;
-				}
-			}
-
+		if (buf[i] == '&') {
 			for (i++; i < buf.size(); i++) {
 				if (buf[i] == '/') {
 					break;
 				}
 
-				ph = ph + buf[i];
+				s1b = s1b + buf[i];
 			}
-
 			if (i == buf.size()) {
-				Display->Warning("Syntax error 3 on simplifying");
-				return true;
+				Display->Warning("Syntax error 2 on simplifying");
+				return;
 			}
-
-			for (i++; i < buf.size(); i++) {
-				if (buf[i] == '/') {
-					break;
-				}
-
-				s2 = s2 + buf[i];
-			}
-
-			if (i == buf.size()) {
-				Display->Warning("Syntax error 4 on simplifying");
-				return true;
-			}
-
-			if (ph == "" && s2 == "") {
-				Display->Warning("Syntax error 5 on simplifying");
-				return true;
-			}
-
-			// if working phrase must be stored and retrieved at the end
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
-				return true;
-			}
-
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
-				return true;
-			}
-
-			if (s1b != "") { // if there is a second cue
-
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1b) == 2) {
-					return true;
-				}
-
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
-					return true;
-				}
-
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
-					return true;
-				}
-			}
-
-			if (s1 != "") {
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1) == 2) {
-					return true;
-				}
-			} else {
-				monitor->GetPhM("WGB", annabell->WGB);
-				s1 = monitor->OutPhrase;
-			}
-
-			cmd_line = PHRASE_CMD + " ";
-
-			if (ph == "") {
-				cmd_line = cmd_line + s1 + " , " + s2; // standard substitution
-			}
-			else {
-				cmd_line = cmd_line + ph;
-			}
-
-			if (ParseCommand(annabell, monitor, Display, clk0, clk1, cmd_line) == 2) {
-				return true;
-			}
-
-			if (s2 != "" && ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s2) == 2) {
-				return true;
-			}
-
-			if (s1b != "") { // drop goal if there was a second cue
-				if (ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
-					return true;
-				}
-			}
-
-			// retrieve working phrase if necessary
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
-				return true;
-			}
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
-				return true;
-			}
-
-		} else if (cmd == PHRASE_CMD || cmd == WORD_GROUP_CMD) {
-			//command is not a macro, and is a phrase or word group command. return false so it can be normally processed.
-			return false;
 		}
-		else {
 
-			//command is not a macro, nor a phrase or wordgroup command.
-			//because simplify is called only for phrase, wordgroup, reward, partial reward and push commands,
-			//it has to be one of reward, partial reward or push.
+		for (i++; i < buf.size(); i++) {
+			if (buf[i] == '/') {
+				break;
+			}
 
+			ph = ph + buf[i];
+		}
+
+		if (i == buf.size()) {
+			Display->Warning("Syntax error 3 on simplifying");
+			return;
+		}
+
+		for (i++; i < buf.size(); i++) {
+			if (buf[i] == '/') {
+				break;
+			}
+
+			s2 = s2 + buf[i];
+		}
+
+		if (i == buf.size()) {
+			Display->Warning("Syntax error 4 on simplifying");
+			return;
+		}
+
+		if (ph == "" && s2 == "") {
+			Display->Warning("Syntax error 5 on simplifying");
+			return;
+		}
+
+		// if working phrase must be stored and retrieved at the end
+		if (push_flag) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
+			ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD);
+		}
+
+		if (s1b != "") { // if there is a second cue
+			ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1b);
+			ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
+			ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD);
+		}
+
+		if (s1 != "") {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s1);
+		} else {
+			monitor->GetPhM("WGB", annabell->WGB);
+			s1 = monitor->OutPhrase;
+		}
+
+		cmd_line = PHRASE_CMD + " ";
+
+		if (ph == "") {
+			cmd_line = cmd_line + s1 + " , " + s2; // standard substitution
+		} else {
+			cmd_line = cmd_line + ph;
+		}
+
+		ParseCommand(annabell, monitor, Display, clk0, clk1, cmd_line);
+		if (s2 != "") {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, string(WORD_GROUP_CMD + " ") + s2);
+		}
+
+		if (s1b != "") { // drop goal if there was a second cue
+			ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG);
+		}
+
+		// retrieve working phrase if necessary
+		if (push_flag) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD);
+			ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG);
+		}
+
+	} else {
+
+		//command is not a macro, nor a phrase or wordgroup command.
+		//because simplify is called only for phrase, wordgroup, reward, partial reward and push commands,
+		//it has to be one of reward, partial reward or push.
+
+		if (push_flag) {
 			//if push flag was true (.ie the abreviated form of command ending in asterisk was used), lets push the goal
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG) == 2) {
-				//this only happens if ParseCommand returned 2, which in turn only happens if entered command is .quit,
-				//which is like never the case, so this most likely never happens.
-				return true;
-			}
+			ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
 
 			//get the goal phrase and use it as a working phrase
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD) == 2) {
-				//this only happens if ParseCommand returned 2, which in turn only happens if entered command is .quit,
-				//which is like never the case, so this most likely never happens.
-				return true;
-			}
-
-			//automatically suggest extracting all tokens from the working phrase
-			cmd_line = WORD_GROUP_CMD;
-
-			for (unsigned int i = 1; i < input_token.size(); i++) {
-				buf = input_token[i];
-				cmd_line = cmd_line + " " + buf;
-			}
-
-			//execute the word group command
-			if (ParseCommand(annabell, monitor, Display, clk0, clk1, cmd_line) == 2) {
-				//this only happens if ParseCommand returned 2, which in turn only happens if entered command is .quit,
-				//which is like never the case, so this most likely never happens.
-				return true;
-			}
-
-			//if push flasg was true that means the goal was pushed, so remove it from the top of the goal stack
-			if (push_flag && ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG) == 2) {
-				//this only happens if ParseCommand returned 2, which in turn only happens if entered command is .quit,
-				//which is like never the case, so this most likely never happens.
-				return true;
-			}
+			ParseCommand(annabell, monitor, Display, clk0, clk1, GET_GOAL_PHRASE_CMD);
 		}
 
-		if (cmd == PARTIAL_REWARD_CMD) {
-			//if it was a partial reward, lets execute it
-			ParseCommand(annabell, monitor, Display, clk0, clk1, PARTIAL_REWARD_CMD2);
-		}
-		else if (cmd == REWARD_CMD) {
-			//if it was a reward, lets execute it
-			ParseCommand(annabell, monitor, Display, clk0, clk1, REWARD_CMD2);
-		}
-		else if (cmd == PUSH_GOAL_CMD) {
-			//if it was a push goal (not an abbreviated one like ".ph*" because that would have lead to push flag being true before), lets execute it
-			ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
+		//automatically suggest extracting all tokens from the working phrase
+		cmd_line = WORD_GROUP_CMD;
+
+		for (unsigned int i = 1; i < input_token.size(); i++) {
+			buf = input_token[i];
+			cmd_line = cmd_line + " " + buf;
 		}
 
-		return true;
+		//execute the word group command
+		ParseCommand(annabell, monitor, Display, clk0, clk1, cmd_line);
+
+		//if push flasg was true that means the goal was pushed, so remove it from the top of the goal stack
+		if (push_flag) {
+			ParseCommand(annabell, monitor, Display, clk0, clk1, DROP_GOAL_CMD_LONG);
+		}
+	}
+
+	if (cmd == PARTIAL_REWARD_CMD) {
+		//if it was a partial reward, lets execute it
+		ParseCommand(annabell, monitor, Display, clk0, clk1, PARTIAL_REWARD_CMD2);
+	} else if (cmd == REWARD_CMD) {
+		//if it was a reward, lets execute it
+		ParseCommand(annabell, monitor, Display, clk0, clk1, REWARD_CMD2);
+	} else if (cmd == PUSH_GOAL_CMD) {
+		//if it was a push goal (not an abbreviated one like ".ph*" because that would have lead to push flag being true before), lets execute it
+		ParseCommand(annabell, monitor, Display, clk0, clk1, PUSH_GOAL_CMD_LONG);
+	}
 }


### PR DESCRIPTION
… convenient methods to encapsulate such checks. Now simplify returns void, so no check is needed when called. Removed checks of return value == 2 inside simplify, since is very unlikely that a macro command issues the .quit command.