### PR TITLE
New MacroCommand and InputPhraseCommand

### DIFF
--- a/src/AnnabellFlags.cc
+++ b/src/AnnabellFlags.cc
@@ -16,9 +16,12 @@ AnnabellFlags::AnnabellFlags() {
 
 	AnswerTimePhrase = "? do you have any friend -s";
 	SpeakerName = "HUM";
+
+	ExplorationPhaseIdx = 0;
+	OutPhrase = "";
+	CompleteOutputFlag = true;
 }
 
 AnnabellFlags::~AnnabellFlags() {
-	// TODO Auto-generated destructor stub
 }
 

--- a/src/AnnabellFlags.h
+++ b/src/AnnabellFlags.h
@@ -29,6 +29,10 @@ public:
 
 	string AnswerTimePhrase;
 	string SpeakerName;
+
+	int ExplorationPhaseIdx;
+	string OutPhrase;
+	bool CompleteOutputFlag;
 };
 
 #endif /* SRC_ANNABELLFLAGS_H_ */

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -32,7 +32,6 @@ string OutPhrase="";
 bool CompleteOutputFlag=true;
 
 int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* clk0, timespec* clk1, string input_line);
-bool simplify(Annabell *annabell, Monitor *Mon, display* Display, timespec* clk0, timespec* clk1, vector<string> input_token);
 int GetInputPhrase(Annabell *annabell, Monitor *Mon, string input_phrase);
 int ExecuteAct(Annabell *annabell, Monitor *Mon, int rwd_act, int acq_act, int el_act);
 string Exploitation(Annabell *annabell, Monitor *Mon, display* Display, int n_iter);
@@ -86,40 +85,6 @@ int Command::execute() {
 }
 
 /**
- * @returns true is specified command supports macro form
- * (doesn't mean the input line is actually a macro, just that there is a possibility that it is one.
- */
-bool isPossibleMacroCommand(const vector<string>& input_token) {
-	return CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD)
-			|| CommandUtils::startsWith(input_token[0], REWARD_CMD)
-			|| CommandUtils::startsWith(input_token[0], PARTIAL_REWARD_CMD)
-			|| CommandUtils::startsWith(input_token[0], PUSH_GOAL_CMD)
-			|| CommandUtils::startsWith(input_token[0], PHRASE_CMD);
-}
-
-/**
- * @returns true if this input is possibly a macro command
- */
-bool isPossibleMacro(const vector<string>& input_token) {
-	return input_token.size() >= 2 && isPossibleMacroCommand(input_token);
-}
-
-/**
- * @returns true is this input is a simple macro command (ie. it is a macro composed by two tokens)
- */
-bool isSimpleMacroCommand(const vector<string>& input_token) {
-	return input_token.size() == 2 && CommandUtils::startsWith(input_token[1], '/');
-}
-
-/**
- * @returns true is this input does not correspond to neither a PHRASE command, nor to a WORD_GROUP command.
- */
-bool isNotPhraseOrWordGroup(const vector<string>& input_token) {
-	return !CommandUtils::startsWith(input_token[0], PHRASE_CMD)
-			&& !CommandUtils::startsWith(input_token[0], WORD_GROUP_CMD);
-}
-
-/**
  * Read command or input phrase from command line.
  * @returns 2 for .quit command.
  */
@@ -145,12 +110,6 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 
 		input_token.push_back(buf);
 		buf = "";
-	}
-
-	if (isPossibleMacro(input_token) && (isSimpleMacroCommand(input_token) || isNotPhraseOrWordGroup(input_token))) {
-
-		simplify(annabell, Mon, Display, clk0, clk1, input_token);
-		return 0;
 	}
 
   string target_phrase;

--- a/src/Command.cc
+++ b/src/Command.cc
@@ -93,23 +93,15 @@ int ParseCommand(Annabell *annabell, Monitor *Mon, display* Display, timespec* c
 	vector<string> input_token;
 
 	stringstream ss(input_line); // Insert the line into a stream
-	string buf, buf1; // buffer strings
+	string buf;
 
-	buf = "";
-	while (ss >> buf1) { // split line in string tokens
-		buf1 = CommandUtils::processArticle(buf1);
+	string parsedToken;
+	while (ss >> parsedToken) {
 
-		buf1 = CommandUtils::processPlural(buf1);
+		parsedToken = CommandUtils::processArticle(parsedToken);
+		parsedToken = CommandUtils::processPlural(parsedToken);
 
-		buf = buf + buf1;
-
-		if (CommandUtils::startsWith(buf, '/') && !CommandUtils::endsWith(buf, '/')) {
-			buf = buf + " ";
-			continue;
-		}
-
-		input_token.push_back(buf);
-		buf = "";
+		input_token.push_back(parsedToken);
 	}
 
   string target_phrase;

--- a/src/Command.h
+++ b/src/Command.h
@@ -15,6 +15,12 @@
 
 using namespace std;
 
+int ExecuteAct(Annabell *annabell, Monitor *Mon, int rwd_act, int acq_act, int el_act);
+int GetInputPhrase(Annabell *annabell, Monitor *Mon, string input_phrase);
+int BuildAs(Annabell *annabell, Monitor *Mon);
+string Exploitation(Annabell *annabell, Monitor *Mon, display* Display, int n_iter);
+int CheckSensoryMotor(string out_phrase, Annabell *annabell, display* Display);
+
 class Command {
 protected:
 	Annabell* annabell;

--- a/src/CommandFactory.cc
+++ b/src/CommandFactory.cc
@@ -13,6 +13,7 @@
 #include <FileCommand.h>
 #include <QuitCommand.h>
 #include <MacroCommand.h>
+#include <InputPhraseCommand.h>
 
 struct timespec;
 
@@ -44,8 +45,12 @@ Command* CommandFactory::newCommand(string input) {
 
 	} else if (CommandUtils::startsWith(input, QUIT_CMD) || CommandUtils::startsWith(input, QUIT_CMD_LONG)) {
 		newCommand = new QuitCommand();
+
 	} else if (CommandUtils::isMacroCommand(input)) {
 		newCommand = new MacroCommand();
+
+	} else if (CommandUtils::isInputPhrase(input)) {
+		newCommand = new InputPhraseCommand();
 	} else {
 		newCommand = new Command();
 	}

--- a/src/CommandFactory.cc
+++ b/src/CommandFactory.cc
@@ -12,6 +12,7 @@
 #include <EmptyCommand.h>
 #include <FileCommand.h>
 #include <QuitCommand.h>
+#include <MacroCommand.h>
 
 struct timespec;
 
@@ -43,7 +44,8 @@ Command* CommandFactory::newCommand(string input) {
 
 	} else if (CommandUtils::startsWith(input, QUIT_CMD) || CommandUtils::startsWith(input, QUIT_CMD_LONG)) {
 		newCommand = new QuitCommand();
-
+	} else if (CommandUtils::isMacroCommand(input)) {
+		newCommand = new MacroCommand();
 	} else {
 		newCommand = new Command();
 	}

--- a/src/CommandUtils.cc
+++ b/src/CommandUtils.cc
@@ -84,7 +84,13 @@ bool CommandUtils::isMacroCommand(string inputString) {
 
 		//TODO: replace with exception thrown
 		exit(matchesCount);
+
 	}
+}
+
+
+bool CommandUtils::isInputPhrase(string input) {
+	return !CommandUtils::startsWith(input, '.') || CommandUtils::startsWith(input, "...");
 }
 
 /**

--- a/src/CommandUtils.h
+++ b/src/CommandUtils.h
@@ -27,7 +27,15 @@ public:
 	 */
 	static void compileRegex(const char* regexString);
 
+	/**
+	 * @returns true is the input corresponds to a command in macro form
+	 */
 	static bool isMacroCommand(string input);
+
+	/**
+	 * @returns true if the input corresponds to a input phrase (ie. is not a "command" per se)
+	 */
+	static bool isInputPhrase(string input);
 
 	/**
 	 * This function takes care of plural suffix.

--- a/src/InputPhraseCommand.cc
+++ b/src/InputPhraseCommand.cc
@@ -1,0 +1,28 @@
+#include "InputPhraseCommand.h"
+
+InputPhraseCommand::InputPhraseCommand() :
+		Command() {
+}
+
+int InputPhraseCommand::execute() {
+	if (annabell->flags->SpeakerFlag) {
+		Display->Print("*" + annabell->flags->SpeakerName + ":\t"); //("*TEA:\t");
+	}
+
+	Display->Print(input_line + "\n");
+	ExecuteAct(annabell, Mon, STORE_ST_A, NULL_ACT, FLUSH_OUT);
+	GetInputPhrase(annabell, Mon, input_line);
+	BuildAs(annabell, Mon);
+	//BuildAsTest(annabell, Mon);
+
+	// check if automatic-exploitation flag is ON
+	if (annabell->flags->AutoExploitFlag) {
+		annabell->flags->OutPhrase = Exploitation(annabell, Mon, Display, 1);
+		annabell->flags->CompleteOutputFlag = true;
+
+		// check if the output is a sensorymotor command
+		CheckSensoryMotor(annabell->flags->OutPhrase, annabell, Display);
+	}
+
+	return 0;
+}

--- a/src/InputPhraseCommand.h
+++ b/src/InputPhraseCommand.h
@@ -1,0 +1,15 @@
+#ifndef SRC_INPUTPHRASECOMMAND_H_
+#define SRC_INPUTPHRASECOMMAND_H_
+
+#include "Command.h"
+
+/**
+ * Class InputPhraseCommand represents the action corresponding to when the user enters simple phrase as input.
+ */
+class InputPhraseCommand: public Command {
+public:
+	InputPhraseCommand();
+	int execute();
+};
+
+#endif /* SRC_INPUTPHRASECOMMAND_H_ */

--- a/src/MacroCommand.cc
+++ b/src/MacroCommand.cc
@@ -1,0 +1,42 @@
+#include <Command.h>
+#include <CommandUtils.h>
+#include <MacroCommand.h>
+#include <string>
+#include <vector>
+
+struct timespec;
+
+bool simplify(Annabell *annabell, Monitor *Mon, display* Display, timespec* clk0, timespec* clk1,
+		vector<string> input_token);
+
+MacroCommand::MacroCommand() :
+		Command() {
+}
+
+int MacroCommand::execute() {
+	//TODO this is duplicated with Command::ParseCommand, for now.
+	vector<string> input_token;
+
+	stringstream ss(input_line); // Insert the line into a stream
+	string buf, buf1; // buffer strings
+
+	buf = "";
+	while (ss >> buf1) { // split line in string tokens
+		buf1 = CommandUtils::processArticle(buf1);
+
+		buf1 = CommandUtils::processPlural(buf1);
+
+		buf = buf + buf1;
+
+		if (CommandUtils::startsWith(buf, '/') && !CommandUtils::endsWith(buf, '/')) {
+			buf = buf + " ";
+			continue;
+		}
+
+		input_token.push_back(buf);
+		buf = "";
+	}
+
+	simplify(annabell, Mon, Display, clk0, clk1, input_token);
+	return 0;
+}

--- a/src/MacroCommand.h
+++ b/src/MacroCommand.h
@@ -1,0 +1,16 @@
+#ifndef SRC_MACROCOMMAND_H_
+#define SRC_MACROCOMMAND_H_
+
+#include "Command.h"
+
+/**
+ * Class MacroCommand represents the action corresponding to when the user enters a command in a macro form.
+ * This command will call, in turn, the individual commands equivalent to the specified macro.
+ */
+class MacroCommand: public Command {
+public:
+	MacroCommand();
+	int execute();
+};
+
+#endif /* SRC_COMMENTCOMMAND_H_ */

--- a/src/MacroCommand.h
+++ b/src/MacroCommand.h
@@ -13,4 +13,4 @@ public:
 	int execute();
 };
 
-#endif /* SRC_COMMENTCOMMAND_H_ */
+#endif /* SRC_MACROCOMMAND_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h FileCommand.h QuitCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h MacroCommand.h FileCommand.h QuitCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc FileCommand.cc QuitCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
+annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc MacroCommand.cc FileCommand.cc QuitCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 annabellincludedir = ${includedir}/annabell
 
-annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h MacroCommand.h FileCommand.h QuitCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
+annabellinclude_HEADERS = CommandConstants.h CommandUtils.h AnnabellParams.h AnnabellFlags.h Command.h EmptyCommand.h CommentCommand.h MacroCommand.h InputPhraseCommand.h FileCommand.h QuitCommand.h CommandFactory.h display.h  enum_ssm.h  fssm.h  interface.h  Monitor.h  rnd.h  sizes.h  Annabell.h  ssm.h  ann_exception.h gettime.h ParseCommandTests.h sensorymotor.h
 
 bin_PROGRAMS = annabell
 
-annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc MacroCommand.cc FileCommand.cc QuitCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
+annabell_SOURCES = AnnabellFlags.cc AnnabellParams.cc CommandUtils.cc Command.cc EmptyCommand.cc CommentCommand.cc MacroCommand.cc InputPhraseCommand.cc FileCommand.cc QuitCommand.cc CommandFactory.cc annabell_main.cc Annabell.cc ssm.cc interface.cc Monitor.cc rnd.cc addref.cc fssm.cc display.cc modes.cc goals.cc ssm_omp.cc ssm_file.cc simplify.cc gettime.cc ParseCommandTests.cc sensorymotor.cc yarpinterface.cc
 
 annabell_CPPFLAGS = @OPENMP_CXXFLAGS@
 annabell_LDFLAGS = @OPENMP_CXXFLAGS@ -lgtest -lpthread -lpcre


### PR DESCRIPTION
Hi Bruno,
this PR includes the creation of new `Command` subclasses `MacroCommand` and `InputPhraseCommand`.

Now `CommandFactory` uses the regex that we included a couple of weeks ago to detect if the user entered a command in a macro form, and derives the corresponding processing to `MacroCommand`.

`InputPhraseCommand` on the other hand, is the corresponding logic to when the user enters simply a phrase.

Related to the creation of this commands, now the flags related to exploration are part of Annabell internal state, and thus can be shared across multiple commands.

I've tested this against both simple examples and simplify variations and seems to be working ok, but as always if you encounter anything strange just let me know.

best,
-Juan